### PR TITLE
Cigar integration

### DIFF
--- a/include/ProgOpts.hpp
+++ b/include/ProgOpts.hpp
@@ -94,7 +94,7 @@ public:
   int32_t gapOpenPenalty{5};
   int32_t gapExtendPenalty{3};
   int32_t matchScore{2};
-  int32_t missMatchScore{-4};
+  int32_t mismatchScore{-4};
   uint32_t refExtendLength{20};
   double minScoreFraction{0.65};
   bool fullAlignment{false};

--- a/include/PuffAligner.hpp
+++ b/include/PuffAligner.hpp
@@ -57,11 +57,14 @@ class PuffAligner {
 public:
   PuffAligner(compact::vector<uint64_t, 2>& ar, std::vector<uint64_t>& ral, uint32_t k_, 
               pufferfish::util::AlignmentConfig& m, ksw2pp::KSW2Aligner& a) : 
-    allRefSeq(ar), refAccumLengths(ral), k(k_),
-    mopts(m), aligner(a), scoreStatus_(m.matchScore,m.minScoreFraction,m.bestStrata, m.decoyPresent) {
+    allRefSeq(ar), refAccumLengths(ral), k(k_) ,
+    mopts(m), aligner(a), scoreStatus_(m.matchScore, m.minScoreFraction, m.bestStrata, m.decoyPresent) {
+
     ksw_reset_extz(&ez);
-		alnCacheLeft.reserve(32);
-		alnCacheRight.reserve(32);
+    alnCacheLeft.reserve(32);
+    alnCacheRight.reserve(32);
+    minLengthGapRequired = mopts.matchScore - mopts.mismatchPenalty > 0 ?
+                           static_cast<uint32_t>((2 * (mopts.gapOpenPenalty + mopts.gapExtendPenalty) + mopts.matchScore ) / (mopts.matchScore - mopts.mismatchPenalty)) : 0;
   }
 
 /*
@@ -97,6 +100,7 @@ private:
   compact::vector<uint64_t, 2>& allRefSeq;
   std::vector<uint64_t>& refAccumLengths;
   uint32_t k;
+  uint32_t minLengthGapRequired;
   pufferfish::util::AlignmentConfig mopts;
   ksw2pp::KSW2Aligner& aligner;
   ksw_extz_t ez;

--- a/include/PuffAligner.hpp
+++ b/include/PuffAligner.hpp
@@ -32,7 +32,7 @@ struct ScoreStatus {
     maxObservedDecoyScore = KSW_NEG_INF;
   }
 
-  int32_t minAcceptedScore(int32_t readlen) { return minScoreFraction * matchScore * readlen; }
+  int32_t minAcceptedScore(int32_t readlen) { return static_cast<int32_t>(std::floor(minScoreFraction * matchScore * readlen)); }
 
   int32_t getCutoff(int32_t retadlen) { return std::max(std::max(maxObservedScore, maxObservedDecoyScore), minAcceptedScore(retadlen)); }
 

--- a/include/PuffAligner.hpp
+++ b/include/PuffAligner.hpp
@@ -85,6 +85,7 @@ public:
 
   bool alignRead(std::string& read, std::string& read_rc, const std::vector<pufferfish::util::MemInfo>& mems, uint64_t queryChainHash, bool perfectChain, bool isFw, size_t tid, AlnCacheMap& alnCache, HitCounters& hctr, AlignmentResult& arOut, bool verbose);
 
+  int32_t align_ungapped(const char* const query, const char* const target, int len);
   bool recoverSingleOrphan(std::string& rl, std::string& rr, pufferfish::util::MemCluster& clust, std::vector<pufferfish::util::MemCluster> &recoveredMemClusters, uint32_t tid, bool anchorIsLeft, bool verbose);
 
   void clearAlnCaches() {alnCacheLeft.clear(); alnCacheRight.clear();}

--- a/include/Util.hpp
+++ b/include/Util.hpp
@@ -862,6 +862,7 @@ Compile-time selection between list-like and map-like printing.
         int16_t matchScore;
         int16_t gapExtendPenalty;
         int16_t gapOpenPenalty;
+        int16_t missMatchPenalty;
         double minScoreFraction{0.0};
         bool mimicBT2{false};
         bool mimicBT2Strict{false};
@@ -871,6 +872,8 @@ Compile-time selection between list-like and map-like printing.
         bool noDovetail{false};
         uint32_t maxFragmentLength{1000};
         PuffAlignmentMode alignmentMode{PuffAlignmentMode::SCORE_ONLY};
+        bool bestStrata{false};
+        bool decoyPresent{false};
       };
 
         struct QuasiAlignment {
@@ -1228,6 +1231,11 @@ Compile-time selection between list-like and map-like printing.
             std::atomic<uint64_t> numDovetails{0};
             std::atomic<uint64_t> tooShortReads{0};
 
+            std::atomic<uint64_t> between_aligner_calls_count{0};
+            std::atomic<uint64_t> begin_aligner_calls_count{0};
+            std::atomic<uint64_t> end_aligner_calls_count{0};
+            std::atomic<uint64_t> not_alignable_skips{0};
+            std::atomic<uint64_t> stopped_count{0};
             std::atomic<uint64_t> skippedAlignments_byCache{0};
             std::atomic<uint64_t> skippedAlignments_byCov{0};
             std::atomic<uint64_t> totalAlignmentAttempts{0};

--- a/include/Util.hpp
+++ b/include/Util.hpp
@@ -1231,11 +1231,7 @@ Compile-time selection between list-like and map-like printing.
             std::atomic<uint64_t> numDovetails{0};
             std::atomic<uint64_t> tooShortReads{0};
 
-            std::atomic<uint64_t> between_aligner_calls_count{0};
-            std::atomic<uint64_t> begin_aligner_calls_count{0};
-            std::atomic<uint64_t> end_aligner_calls_count{0};
-            std::atomic<uint64_t> not_alignable_skips{0};
-            std::atomic<uint64_t> stopped_count{0};
+            std::atomic<uint64_t> skippedAlignments_notAlignable{0};
             std::atomic<uint64_t> skippedAlignments_byCache{0};
             std::atomic<uint64_t> skippedAlignments_byCov{0};
             std::atomic<uint64_t> totalAlignmentAttempts{0};

--- a/include/Util.hpp
+++ b/include/Util.hpp
@@ -862,7 +862,7 @@ Compile-time selection between list-like and map-like printing.
         int16_t matchScore;
         int16_t gapExtendPenalty;
         int16_t gapOpenPenalty;
-        int16_t missMatchPenalty;
+        int16_t mismatchPenalty;
         double minScoreFraction{0.0};
         bool mimicBT2{false};
         bool mimicBT2Strict{false};

--- a/include/ksw2pp/KSW2Aligner.hpp
+++ b/include/ksw2pp/KSW2Aligner.hpp
@@ -66,7 +66,7 @@ public:
 
   int operator()(const char* const queryOriginal, const int queryLength,
                  const char* const targetOriginal, const int targetLength,
-                 ksw_extz_t* ez, EnumToType<KSW2AlignmentType::EXTENSION>);
+                 ksw_extz_t* ez, int cutoff, EnumToType<KSW2AlignmentType::EXTENSION>);
 
   int operator()(const uint8_t* const queryOriginal, const int queryLength,
                  const uint8_t* const targetOriginal, const int targetLength,
@@ -74,7 +74,7 @@ public:
 
   int operator()(const uint8_t* const queryOriginal, const int queryLength,
                  const uint8_t* const targetOriginal, const int targetLength,
-                 ksw_extz_t* ez, EnumToType<KSW2AlignmentType::EXTENSION>);
+                 ksw_extz_t* ez, int cutoff, EnumToType<KSW2AlignmentType::EXTENSION>);
 
   /**
    * Variants of the operator that do not require an output

--- a/include/ksw2pp/ksw2.h
+++ b/include/ksw2pp/ksw2.h
@@ -22,6 +22,7 @@ extern "C" {
 
 typedef struct {
 	uint32_t max:31, zdropped:1;
+	int64_t stopped;
 	int max_q, max_t;      // max extension coordinate
 	int mqe, mqe_t;        // max score when reaching the end of query
 	int mte, mte_q;        // max score when reaching the end of target
@@ -29,9 +30,9 @@ typedef struct {
 	int m_cigar, n_cigar;
 	int reach_end;
 	uint32_t *cigar;
-  int n_cigar1, n_cigar2, n_cigar3;
-  int m_cigar1, m_cigar2, m_cigar3;
-  uint32_t *cigar1, *cigar2, *cigar3;
+//  int n_cigar1, n_cigar2, n_cigar3;
+//  int m_cigar1, m_cigar2, m_cigar3;
+//  uint32_t *cigar1, *cigar2, *cigar3;
   int score_only;
 } ksw_extz_t;
 
@@ -175,6 +176,7 @@ static inline void ksw_reset_extz(ksw_extz_t *ez)
 	ez->max_q = ez->max_t = ez->mqe_t = ez->mte_q = -1;
 	ez->max = 0, ez->score = ez->mqe = ez->mte = KSW_NEG_INF;
 	ez->n_cigar = 0, ez->zdropped = 0, ez->reach_end = 0;
+        ez->stopped = 0;
 }
 
 static inline int ksw_apply_zdrop(ksw_extz_t *ez, int is_rot, int32_t H, int a, int b, int zdrop, int8_t e)

--- a/include/ksw2pp/ksw2.h
+++ b/include/ksw2pp/ksw2.h
@@ -57,11 +57,11 @@ void ksw_extz(void *km, int qlen, const uint8_t *query, int tlen, const uint8_t 
 			  int8_t q, int8_t e, int w, int zdrop, int flag, ksw_extz_t *ez);
 
 void ksw_extz2_sse(/*unsigned int simd, */void *km, int qlen, const uint8_t *query, int tlen, const uint8_t *target, int8_t m, const int8_t *mat,
-				   int8_t q, int8_t e, int w, int zdrop, int end_bonus, int flag, ksw_extz_t *ez);
+				   int8_t q, int8_t e, int w, int zdrop, int end_bonus, int flag, ksw_extz_t *ez, int cutoff);
 void ksw_extz2_sse41(/*unsigned int simd, */void *km, int qlen, const uint8_t *query, int tlen, const uint8_t *target, int8_t m, const int8_t *mat,
-           int8_t q, int8_t e, int w, int zdrop, int end_bonus, int flag, ksw_extz_t *ez);
+           int8_t q, int8_t e, int w, int zdrop, int end_bonus, int flag, ksw_extz_t *ez, int cutoff);
 void ksw_extz2_sse2(/*unsigned int simd, */void *km, int qlen, const uint8_t *query, int tlen, const uint8_t *target, int8_t m, const int8_t *mat,
-           int8_t q, int8_t e, int w, int zdrop, int end_bonus, int flag, ksw_extz_t *ez);
+           int8_t q, int8_t e, int w, int zdrop, int end_bonus, int flag, ksw_extz_t *ez, int cutoff);
 
 
 void ksw_extd(void *km, int qlen, const uint8_t *query, int tlen, const uint8_t *target, int8_t m, const int8_t *mat,

--- a/src/PuffAligner.cpp
+++ b/src/PuffAligner.cpp
@@ -227,7 +227,8 @@ bool PuffAligner::alignRead(std::string& read, std::string& read_rc, const std::
   auto& bandwidth = aligner.config().bandwidth;
   libdivide::divider<int32_t> gapExtDivisor(static_cast<int32_t>(mopts.gapExtendPenalty));
   const int32_t minAcceptedScore = scoreStatus_.getCutoff(read.length()); //mopts.minScoreFraction * mopts.matchScore * readLen;
-  uint32_t minLengthGapRequired = ( 2 * (mopts.gapOpenPenalty + mopts.gapExtendPenalty) + mopts.matchScore ) / (mopts.matchScore - mopts.missMatchPenalty);
+  uint32_t minLengthGapRequired = mopts.matchScore - mopts.missMatchPenalty > 0 ?
+                                  static_cast<uint32_t>( 2 * (mopts.gapOpenPenalty + mopts.gapExtendPenalty) + mopts.matchScore ) / (mopts.matchScore - mopts.missMatchPenalty) : 0;
   // compute the maximum gap length that would be allowed given the length of read aligned so far and the current 
   // alignment score.
   auto maxAllowedGaps = [&minAcceptedScore, &readLen, &gapExtDivisor, this] (uint32_t alignedLen, int32_t alignmentScore) -> int {

--- a/src/PuffAligner.cpp
+++ b/src/PuffAligner.cpp
@@ -348,7 +348,7 @@ bool PuffAligner::alignRead(std::string& read, std::string& read_rc, const std::
       decltype(readStart) readOffset = allowOverhangSoftclip ? readStart : 0;
       nonstd::string_view readSeq = readView.substr(readOffset);
       ksw_reset_extz(&ez);
-      auto cutoff = minAcceptedScore - mopts.matchScore * (read.length()-1);
+      auto cutoff = minAcceptedScore - mopts.matchScore * read.length();
       aligner(readSeq.data(), readSeq.length(), refSeqBuffer_.data(),
               refSeqBuffer_.length(), &ez, cutoff,
               ksw2pp::EnumToType<ksw2pp::KSW2AlignmentType::EXTENSION>());
@@ -414,7 +414,7 @@ bool PuffAligner::alignRead(std::string& read, std::string& read_rc, const std::
           
           ksw_reset_extz(&ez);
           bandwidth = maxAllowedGaps(0, 0) + 1;
-          auto cutoff = minAcceptedScore - mopts.matchScore * (read.length()-1);
+          auto cutoff = minAcceptedScore - mopts.matchScore * read.length();
           aligner(readWindow.data(), readWindow.length(), refSeqBuffer_.data(),
                   refSeqBuffer_.length(), &ez, cutoff,
                   ksw2pp::EnumToType<ksw2pp::KSW2AlignmentType::EXTENSION>());
@@ -653,7 +653,7 @@ bool PuffAligner::alignRead(std::string& read, std::string& read_rc, const std::
 
         if (refLen > 0) {
           ksw_reset_extz(&ez);
-          auto cutoff = minAcceptedScore - alignmentScore - mopts.matchScore * (readWindow.length()-1);
+          auto cutoff = minAcceptedScore - alignmentScore - mopts.matchScore * readWindow.length();
           aligner(readWindow.data(), readWindow.length(), refSeqBuffer_.data(),
                   refLen, &ez, cutoff,
                   ksw2pp::EnumToType<ksw2pp::KSW2AlignmentType::EXTENSION>());
@@ -773,7 +773,7 @@ int32_t PuffAligner::calculateAlignments(std::string& read_left, std::string& re
     bool computeCIGAR = !(aligner.config().flag & KSW_EZ_SCORE_ONLY);
     bool approximateCIGAR = mopts.alignmentMode == pufferfish::util::PuffAlignmentMode::APPROXIMATE_CIGAR;
     auto threshold = [&, optFrac] (uint64_t len) -> double {
-        return (!mopts.matchScore)?(-0.6+-0.6*len):optFrac*mopts.matchScore*len;
+        return static_cast<int32_t>(std::floor((!mopts.matchScore)?(-0.6+-0.6*len):optFrac*mopts.matchScore*len));
     };
     constexpr const auto invalidScore = std::numeric_limits<decltype(ar_left.score)>::min();
 
@@ -853,7 +853,7 @@ int32_t PuffAligner::calculateAlignments(std::string& read, pufferfish::util::Jo
     bool computeCIGAR = !(aligner.config().flag & KSW_EZ_SCORE_ONLY);
     bool approximateCIGAR = mopts.alignmentMode == pufferfish::util::PuffAlignmentMode::APPROXIMATE_CIGAR;
     auto threshold = [&, optFrac] (uint64_t len) -> double {
-        return (!mopts.matchScore)?(-0.6+-0.6*len):optFrac*mopts.matchScore*len;
+        return static_cast<int32_t>(std::floor((!mopts.matchScore)?(-0.6+-0.6*len):optFrac*mopts.matchScore*len));
     };
     constexpr const auto invalidScore = std::numeric_limits<decltype(ar_left.score)>::min();
 

--- a/src/PuffAligner.cpp
+++ b/src/PuffAligner.cpp
@@ -772,7 +772,7 @@ int32_t PuffAligner::calculateAlignments(std::string& read_left, std::string& re
     double optFrac{mopts.minScoreFraction};
     bool computeCIGAR = !(aligner.config().flag & KSW_EZ_SCORE_ONLY);
     bool approximateCIGAR = mopts.alignmentMode == pufferfish::util::PuffAlignmentMode::APPROXIMATE_CIGAR;
-    auto threshold = [&, optFrac] (uint64_t len) -> double {
+    auto threshold = [&, optFrac] (uint64_t len) -> int32_t {
         return static_cast<int32_t>(std::floor((!mopts.matchScore)?(-0.6+-0.6*len):optFrac*mopts.matchScore*len));
     };
     constexpr const auto invalidScore = std::numeric_limits<decltype(ar_left.score)>::min();
@@ -852,7 +852,7 @@ int32_t PuffAligner::calculateAlignments(std::string& read, pufferfish::util::Jo
     double optFrac{mopts.minScoreFraction};
     bool computeCIGAR = !(aligner.config().flag & KSW_EZ_SCORE_ONLY);
     bool approximateCIGAR = mopts.alignmentMode == pufferfish::util::PuffAlignmentMode::APPROXIMATE_CIGAR;
-    auto threshold = [&, optFrac] (uint64_t len) -> double {
+    auto threshold = [&, optFrac] (uint64_t len) -> int32_t {
         return static_cast<int32_t>(std::floor((!mopts.matchScore)?(-0.6+-0.6*len):optFrac*mopts.matchScore*len));
     };
     constexpr const auto invalidScore = std::numeric_limits<decltype(ar_left.score)>::min();

--- a/src/PufferfishAligner.cpp
+++ b/src/PufferfishAligner.cpp
@@ -949,6 +949,7 @@ void printAlignmentSummary(HitCounters &hctrs, std::shared_ptr<spdlog::logger> c
     consoleLog->info("Total number of alignment attempts : {}", hctrs.totalAlignmentAttempts);
     consoleLog->info("Number of skipped alignments because of cache hits : {}", hctrs.skippedAlignments_byCache);
     consoleLog->info("Number of skipped alignments because of perfect chains : {}", hctrs.skippedAlignments_byCov);
+    consoleLog->info("Number of alignments calculations skipped by non-alignable: {}", hctrs.skippedAlignments_notAlignable);
 
     consoleLog->info("Number of cigar strings which are fixed: {}", hctrs.cigar_fixed_count);
     consoleLog->info("=====");

--- a/src/PufferfishAligner.cpp
+++ b/src/PufferfishAligner.cpp
@@ -113,7 +113,7 @@ void processReadsPair(paired_parser *parser,
     pufferfish::util::QueryCache qc;
 
     //Initialize aligner ksw
-    ksw2pp::KSW2Aligner aligner(mopts->matchScore, mopts->missMatchScore);
+    ksw2pp::KSW2Aligner aligner(mopts->matchScore, mopts->mismatchScore);
     ksw2pp::KSW2Config config;
 
     config.dropoff = -1;
@@ -151,7 +151,7 @@ void processReadsPair(paired_parser *parser,
     aconf.useAlignmentCache = mopts->useAlignmentCache;
     aconf.maxFragmentLength = mopts->maxFragmentLength;
     aconf.noDovetail = mopts->noDovetail;
-    aconf.missMatchPenalty = mopts->missMatchScore;
+    aconf.mismatchPenalty = mopts->mismatchScore;
     aconf.bestStrata = mopts->bestStrata;
     aconf.decoyPresent = mopts->filterGenomics or mopts->filterMicrobiom or mopts->filterMicrobiomBestScore;
 
@@ -580,7 +580,7 @@ void processReadsSingle(single_parser *parser,
     std::vector<pufferfish::util::MemCluster> all;
 
     //Initialize aligner ksw
-    ksw2pp::KSW2Aligner aligner(mopts->matchScore, mopts->missMatchScore);
+    ksw2pp::KSW2Aligner aligner(mopts->matchScore, mopts->mismatchScore);
     ksw2pp::KSW2Config config;
 
     config.dropoff = -1;
@@ -608,7 +608,7 @@ void processReadsSingle(single_parser *parser,
     aconf.allowSoftclip = mopts->allowSoftclip;
     aconf.alignmentMode = mopts->noOutput or !mopts->allowSoftclip ? pufferfish::util::PuffAlignmentMode::SCORE_ONLY : pufferfish::util::PuffAlignmentMode::APPROXIMATE_CIGAR;
     aconf.useAlignmentCache = mopts->useAlignmentCache;
-    aconf.missMatchPenalty = mopts->missMatchScore;
+    aconf.mismatchPenalty = mopts->mismatchScore;
     aconf.bestStrata = mopts->bestStrata;
     aconf.decoyPresent = mopts->filterGenomics or mopts->filterMicrobiom or mopts->filterMicrobiomBestScore;
 

--- a/src/ksw2pp/KSW2Aligner.cpp
+++ b/src/ksw2pp/KSW2Aligner.cpp
@@ -1,4 +1,5 @@
 #include "ksw2pp/KSW2Aligner.hpp"
+#include <limits>
 #include <iostream>
 
 /*
@@ -207,6 +208,7 @@ int KSW2Aligner::operator()(const char* const queryOriginal,
                             const int queryLength,
                             const char* const targetOriginal,
                             const int targetLength, ksw_extz_t* ez,
+                            int cutoff,
                             EnumToType<KSW2AlignmentType::EXTENSION>) {
   // NOTE: all ksw extension aligner calls clear out ez 
   // *internally*.  This is why we do not need to (and do not)
@@ -225,11 +227,11 @@ int KSW2Aligner::operator()(const char* const queryOriginal,
   if (haveSSE41) {
     ksw_extz2_sse41(kalloc_allocator_.get(), qlen, query_.data(), tlen,
                 target_.data(), config_.alphabetSize, mat_.data(), q, e, w, z,
-                config_.end_bonus, config_.flag, ez);
+                config_.end_bonus, config_.flag, ez, cutoff);
   } else if (haveSSE2) {
     ksw_extz2_sse2(kalloc_allocator_.get(), qlen, query_.data(), tlen,
                   target_.data(), config_.alphabetSize, mat_.data(), q, e, w, z,
-                  config_.end_bonus, config_.flag, ez);
+                  config_.end_bonus, config_.flag, ez, cutoff);
   } else {
     std::abort();
   }
@@ -242,7 +244,7 @@ int KSW2Aligner::operator()(const char* const queryOriginal,
                             const int targetLength,
                             EnumToType<KSW2AlignmentType::EXTENSION>) {
   return this->operator()(queryOriginal, queryLength, targetOriginal,
-                          targetLength, &result_,
+                          targetLength, &result_, std::numeric_limits<int>::min(),
                           EnumToType<KSW2AlignmentType::EXTENSION>());
 }
 
@@ -254,7 +256,7 @@ int KSW2Aligner::operator()(const char* const queryOriginal,
   switch (config_.atype) {
   case KSW2AlignmentType::EXTENSION:
     ret = this->operator()(queryOriginal, queryLength, targetOriginal,
-                           targetLength, &result_,
+                           targetLength, &result_, std::numeric_limits<int>::min(),
                            EnumToType<KSW2AlignmentType::EXTENSION>());
     break;
   case KSW2AlignmentType::GLOBAL:
@@ -341,7 +343,7 @@ int KSW2Aligner::operator()(const uint8_t* const query_, const int queryLength,
   int ret{0};
   switch (config_.atype) {
   case KSW2AlignmentType::EXTENSION:
-    ret = this->operator()(query_, queryLength, target_, targetLength, &result_,
+    ret = this->operator()(query_, queryLength, target_, targetLength, &result_, std::numeric_limits<int>::min(),
                            EnumToType<KSW2AlignmentType::EXTENSION>());
     break;
   case KSW2AlignmentType::GLOBAL:
@@ -354,7 +356,7 @@ int KSW2Aligner::operator()(const uint8_t* const query_, const int queryLength,
 
 int KSW2Aligner::operator()(const uint8_t* const query_, const int queryLength,
                             const uint8_t* const target_,
-                            const int targetLength, ksw_extz_t* ez,
+                            const int targetLength, ksw_extz_t* ez, int cutoff,
                             EnumToType<KSW2AlignmentType::EXTENSION>) {
   // NOTE: all ksw extension aligner calls clear out ez 
   // *internally*.  This is why we do not need to (and do not)
@@ -370,11 +372,11 @@ int KSW2Aligner::operator()(const uint8_t* const query_, const int queryLength,
   if (haveSSE41) {
     ksw_extz2_sse41(kalloc_allocator_.get(), qlen, query_, tlen, target_,
                 config_.alphabetSize, mat_.data(), q, e, w, z, config_.end_bonus, config_.flag,
-                ez);
+                ez, cutoff);
   } else if (haveSSE2) {
     ksw_extz2_sse2(kalloc_allocator_.get(), qlen, query_, tlen, target_,
                   config_.alphabetSize, mat_.data(), q, e, w, z, config_.end_bonus, config_.flag,
-                  ez);
+                  ez, cutoff);
   } else {
     std::abort();
   }
@@ -385,7 +387,7 @@ int KSW2Aligner::operator()(const uint8_t* const query_, const int queryLength,
                             const uint8_t* const target_,
                             const int targetLength,
                             EnumToType<KSW2AlignmentType::EXTENSION>) {
-  return this->operator()(query_, queryLength, target_, targetLength, &result_,
+  return this->operator()(query_, queryLength, target_, targetLength, &result_, std::numeric_limits<int>::min(),
                           EnumToType<KSW2AlignmentType::EXTENSION>());
 }
 

--- a/src/ksw2pp/ksw2_extz2_sse.c
+++ b/src/ksw2pp/ksw2_extz2_sse.c
@@ -15,12 +15,12 @@
 
 #ifdef KSW_CPU_DISPATCH
 #ifdef __SSE4_1__
-void ksw_extz2_sse41(void *km, int qlen, const uint8_t *query, int tlen, const uint8_t *target, int8_t m, const int8_t *mat, int8_t q, int8_t e, int w, int zdrop, int end_bonus, int flag, ksw_extz_t *ez)
+void ksw_extz2_sse41(void *km, int qlen, const uint8_t *query, int tlen, const uint8_t *target, int8_t m, const int8_t *mat, int8_t q, int8_t e, int w, int zdrop, int end_bonus, int flag, ksw_extz_t *ez, int cutoff)
 #else
-void ksw_extz2_sse2(void *km, int qlen, const uint8_t *query, int tlen, const uint8_t *target, int8_t m, const int8_t *mat, int8_t q, int8_t e, int w, int zdrop, int end_bonus, int flag, ksw_extz_t *ez)
+void ksw_extz2_sse2(void *km, int qlen, const uint8_t *query, int tlen, const uint8_t *target, int8_t m, const int8_t *mat, int8_t q, int8_t e, int w, int zdrop, int end_bonus, int flag, ksw_extz_t *ez, int cutoff)
 #endif
 #else
-void ksw_extz2_sse(void *km, int qlen, const uint8_t *query, int tlen, const uint8_t *target, int8_t m, const int8_t *mat, int8_t q, int8_t e, int w, int zdrop, int end_bonus, int flag, ksw_extz_t *ez)
+void ksw_extz2_sse(void *km, int qlen, const uint8_t *query, int tlen, const uint8_t *target, int8_t m, const int8_t *mat, int8_t q, int8_t e, int w, int zdrop, int end_bonus, int flag, ksw_extz_t *ez, int cutoff)
 #endif // ~KSW_CPU_DISPATCH
 {
 #define __dp_code_block1 \
@@ -46,7 +46,7 @@ void ksw_extz2_sse(void *km, int qlen, const uint8_t *query, int tlen, const uin
 	a = _mm_sub_epi8(a, z); \
 	b = _mm_sub_epi8(b, z);
 
-	int r, t, qe = q + e, n_col_, *off = 0, *off_end = 0, tlen_, qlen_, last_st, last_en, wl, wr, max_sc, min_sc;
+	int r, t, qe = q + e, n_col_, *off = 0, *off_end = 0, tlen_, qlen_, last_st, last_en, wl, wr, max_sc, min_sc, match_score = mat[0];;
 	int with_cigar = !(flag&KSW_EZ_SCORE_ONLY), approx_max = !!(flag&KSW_EZ_APPROX_MAX);
 	int32_t *H = 0, H0 = 0, last_H0_t = 0;
 	uint8_t *qr, *sf, *mem, *mem2 = 0;
@@ -97,6 +97,7 @@ void ksw_extz2_sse(void *km, int qlen, const uint8_t *query, int tlen, const uin
 
 	for (t = 0; t < qlen; ++t) qr[t] = query[qlen - 1 - t];
 	memcpy(sf, target, tlen);
+        int max_achievable_score = KSW_NEG_INF, max_achievable_score_prev = KSW_NEG_INF;
 
 	for (r = 0, last_st = last_en = -1; r < qlen + tlen - 1; ++r) {
 		int st = 0, en = tlen - 1, st0, en0, st_, en_;
@@ -225,15 +226,18 @@ void ksw_extz2_sse(void *km, int qlen, const uint8_t *query, int tlen, const uin
 			int32_t max_H, max_t;
 			// compute H[], max_H and max_t
 			if (r > 0) {
-				int32_t HH[4], tt[4], en1 = st0 + (en0 - st0) / 4 * 4, i;
-				__m128i max_H_, max_t_, qe_;
+				int32_t HH[4], tt[4], mm[4], en1 = st0 + (en0 - st0) / 4 * 4, i;
+				__m128i max_H_, max_t_, qe_, tj, max_achievable_score_, H_achievable_score_;
 				max_H = H[en0] = en0 > 0? H[en0-1] + u8[en0] - qe : H[en0] + v8[en0] - qe; // special casing the last element
 				max_t = en0;
 				max_H_ = _mm_set1_epi32(max_H);
 				max_t_ = _mm_set1_epi32(max_t);
 				qe_    = _mm_set1_epi32(q + e);
+
+				max_achievable_score = max_H+(max_t-r)*match_score;
+				max_achievable_score_ = _mm_set1_epi32(max_achievable_score);
 				for (t = st0; t < en1; t += 4) { // this implements: H[t]+=v8[t]-qe; if(H[t]>max_H) max_H=H[t],max_t=t;
-					__m128i H1, tmp, t_;
+					__m128i H1, tmp, t_, tmp_achievalbe_score;
 					H1 = _mm_loadu_si128((__m128i*)&H[t]);
 					t_ = _mm_setr_epi32(v8[t], v8[t+1], v8[t+2], v8[t+3]);
 					H1 = _mm_add_epi32(H1, t_);
@@ -241,22 +245,34 @@ void ksw_extz2_sse(void *km, int qlen, const uint8_t *query, int tlen, const uin
 					_mm_storeu_si128((__m128i*)&H[t], H1);
 					t_ = _mm_set1_epi32(t);
 					tmp = _mm_cmpgt_epi32(H1, max_H_);
+
+					tj = _mm_setr_epi32(match_score*(t-r),match_score*(t+1-r),match_score*(t+2-r),match_score*(t+3-r));
+					H_achievable_score_ = _mm_add_epi32(H1, tj);
+					tmp_achievalbe_score = _mm_cmpgt_epi32(H_achievable_score_, max_achievable_score_);
 #ifdef __SSE4_1__
 					max_H_ = _mm_blendv_epi8(max_H_, H1, tmp);
 					max_t_ = _mm_blendv_epi8(max_t_, t_, tmp);
+					max_achievable_score_ = _mm_blendv_epi8(max_achievable_score_, H_achievable_score_, tmp_achievalbe_score);
 #else
 					max_H_ = _mm_or_si128(_mm_and_si128(tmp, H1), _mm_andnot_si128(tmp, max_H_));
 					max_t_ = _mm_or_si128(_mm_and_si128(tmp, t_), _mm_andnot_si128(tmp, max_t_));
+					max_achievable_score_ = _mm_or_si128(_mm_and_si128(tmp_achievalbe_score, H_achievable_score_),
+                                                                             _mm_andnot_si128(tmp_achievalbe_score, max_achievable_score_));
 #endif
 				}
 				_mm_storeu_si128((__m128i*)HH, max_H_);
 				_mm_storeu_si128((__m128i*)tt, max_t_);
-				for (i = 0; i < 4; ++i)
+				_mm_storeu_si128((__m128i*)mm, max_achievable_score_);
+				for (i = 0; i < 4; ++i) {
 					if (max_H < HH[i]) max_H = HH[i], max_t = tt[i] + i;
+                                        if (max_achievable_score < mm[i]) max_achievable_score = mm[i];
+                                }
 				for (; t < en0; ++t) { // for the rest of values that haven't been computed with SSE
 					H[t] += (int32_t)v8[t] - qe;
 					if (H[t] > max_H)
 						max_H = H[t], max_t = t;
+					if (H[t] + match_score*(t-r) > max_achievable_score)
+						max_achievable_score = H[t] + match_score*(t-r);
 				}
 			} else H[0] = v8[0] - qe - qe, max_H = H[0], max_t = 0; // special casing r==0
 			// update ez
@@ -267,6 +283,10 @@ void ksw_extz2_sse(void *km, int qlen, const uint8_t *query, int tlen, const uin
 			if (ksw_apply_zdrop(ez, 1, max_H, r, max_t, zdrop, e)) break;
 			if (r == qlen + tlen - 2 && en0 == tlen - 1)
 				ez->score = H[tlen - 1];
+			// check if the score is achievable
+			int max = max_achievable_score > max_achievable_score_prev ? max_achievable_score : max_achievable_score_prev;
+			if (r>1 && max < cutoff ) { ez->stopped = 1; break; }
+			max_achievable_score_prev = max_achievable_score;
 		} else { // find approximate max; Z-drop might be inaccurate, too.
 			if (r > 0) {
 				if (last_H0_t >= st0 && last_H0_t <= en0 && last_H0_t + 1 >= st0 && last_H0_t + 1 <= en0) {


### PR DESCRIPTION
This is the first pull request for the integration of the changes from cigar-strings branch to develop branch. This pull request includes only improvements regarding the performance of the alignment computation step in PuffAligner. These improvements mostly consist of early exits during the between-Mem alignment procedure, that is, by knowing the alignment score computed for a query up to a position sometimes we can guarantee aligning the rest of the query, even if it's going to be a perfect match, is not going to make any difference in terms of that alignment be acceptable by the alignment score threshold condition. The early exits occur both between every aligner call, and also during the DP procedure of KSW2.