### PR TITLE
Implementation of soft-clipping and CIGAR computation

### DIFF
--- a/include/ProgOpts.hpp
+++ b/include/ProgOpts.hpp
@@ -127,6 +127,8 @@ public:
   // bool allowSoftclip{false};
   bool computeCIGAR{false};
   bool debug{false};
+  bool end2end{false};
+  uint32_t endBonus{5};
   bool useAlignmentCache{true};
   uint32_t alignmentStreamLimit{10000};
   double preMergeChainSubThresh{0.9};

--- a/include/ProgOpts.hpp
+++ b/include/ProgOpts.hpp
@@ -123,7 +123,6 @@ public:
   bool recoverOrphans{false};
   bool mimicBt2Default{false};
   bool mimicBt2Strict{false};
-  // bool allowOverhangSoftclip{false};
   bool allowSoftclip{false};
   bool computeCIGAR{false};
   bool debug{false};

--- a/include/ProgOpts.hpp
+++ b/include/ProgOpts.hpp
@@ -123,8 +123,10 @@ public:
   bool recoverOrphans{false};
   bool mimicBt2Default{false};
   bool mimicBt2Strict{false};
-  bool allowOverhangSoftclip{false};
-  bool allowSoftclip{false};
+  // bool allowOverhangSoftclip{false};
+  // bool allowSoftclip{false};
+  bool computeCIGAR{false};
+  bool debug{false};
   bool useAlignmentCache{true};
   uint32_t alignmentStreamLimit{10000};
   double preMergeChainSubThresh{0.9};

--- a/include/ProgOpts.hpp
+++ b/include/ProgOpts.hpp
@@ -124,10 +124,10 @@ public:
   bool mimicBt2Default{false};
   bool mimicBt2Strict{false};
   // bool allowOverhangSoftclip{false};
-  // bool allowSoftclip{false};
+  bool allowSoftclip{false};
   bool computeCIGAR{false};
   bool debug{false};
-  bool end2end{false};
+  bool end2end{true};
   double maxSoftclipFraction{0.2};
   uint32_t endBonus{5};
   bool useAlignmentCache{true};

--- a/include/ProgOpts.hpp
+++ b/include/ProgOpts.hpp
@@ -128,6 +128,7 @@ public:
   bool computeCIGAR{false};
   bool debug{false};
   bool end2end{false};
+  double maxSoftclipFraction{0.2};
   uint32_t endBonus{5};
   bool useAlignmentCache{true};
   uint32_t alignmentStreamLimit{10000};

--- a/include/ProgOpts.hpp
+++ b/include/ProgOpts.hpp
@@ -127,7 +127,8 @@ public:
   bool computeCIGAR{false};
   bool debug{false};
   bool end2end{true};
-  double maxSoftclipFraction{0.2};
+  double maxSoftclipFractionGeneral{0.2};
+  double maxSoftclipFractionOverhang{0.2};
   uint32_t endBonus{5};
   bool useAlignmentCache{true};
   uint32_t alignmentStreamLimit{10000};

--- a/include/PuffAligner.hpp
+++ b/include/PuffAligner.hpp
@@ -83,10 +83,10 @@ public:
   PuffAligner(PuffAligner&& other) = delete;
   PuffAligner& operator=(PuffAligner&& other) = delete;
 
-  int32_t calculateAlignments(std::string& rl, std::string& rr, pufferfish::util::JointMems& jointHit, HitCounters& hctr, bool isMultimapping, bool verbose);
-  int32_t calculateAlignments(std::string& read, pufferfish::util::JointMems& jointHit, HitCounters& hctr, bool isMultimapping, bool verbose);
+  int32_t calculateAlignments(std::string& rl, std::string& rr, pufferfish::util::JointMems& jointHit, HitCounters& hctr, bool isMultimapping, std::shared_ptr<spdlog::logger>& logger_, bool verbose);
+  int32_t calculateAlignments(std::string& read, pufferfish::util::JointMems& jointHit, HitCounters& hctr, bool isMultimapping, std::shared_ptr<spdlog::logger>& logger_, bool verbose);
 
-  bool alignRead(std::string& read, std::string& read_rc, const std::vector<pufferfish::util::MemInfo>& mems, uint64_t queryChainHash, bool perfectChain, bool isFw, size_t tid, AlnCacheMap& alnCache, HitCounters& hctr, AlignmentResult& arOut, bool verbose);
+  bool alignRead(std::string& read, std::string& read_rc, const std::vector<pufferfish::util::MemInfo>& mems, uint64_t queryChainHash, bool perfectChain, bool isFw, size_t tid, AlnCacheMap& alnCache, HitCounters& hctr, AlignmentResult& arOut, std::shared_ptr<spdlog::logger>& logger_, bool verbose);
 
   int32_t align_ungapped(const char* const query, const char* const target, int len);
   bool recoverSingleOrphan(std::string& rl, std::string& rr, pufferfish::util::MemCluster& clust, std::vector<pufferfish::util::MemCluster> &recoveredMemClusters, uint32_t tid, bool anchorIsLeft, bool verbose);

--- a/include/Util.hpp
+++ b/include/Util.hpp
@@ -825,7 +825,6 @@ Compile-time selection between list-like and map-like printing.
         bool end2end{true};
         double maxSoftclipFractionGeneral{0.2};
         double maxSoftclipFractionOverhang{0.2};
-        uint32_t endBonus{5};
         bool useAlignmentCache{true};
         bool noDovetail{false};
         uint32_t maxFragmentLength{1000};

--- a/include/Util.hpp
+++ b/include/Util.hpp
@@ -401,7 +401,7 @@ Compile-time selection between list-like and map-like printing.
         std::string cigar_types;
         int32_t begin_softclip_len{0}, end_softclip_len{0};
         bool beginOverhang{false}, endOverhang{false};
-        bool allowOverhangSoftClip{false};
+        // bool allowOverhangSoftClip{false};
 
         void clear() {
           cigar_counts.clear(); cigar_types.clear();
@@ -905,9 +905,9 @@ Compile-time selection between list-like and map-like printing.
         bool mimicBT2{false};
         bool mimicBT2Strict{false};
         // bool allowOverhangSoftclip{false};
-        // bool allowSoftclip{false};
+        bool allowSoftclip{false};
         bool computeCIGAR{false};
-        bool end2end{false};
+        bool end2end{true};
         double maxSoftclipFraction{0.2};
         uint32_t endBonus{5};
         bool useAlignmentCache{true};

--- a/include/Util.hpp
+++ b/include/Util.hpp
@@ -397,7 +397,7 @@ Compile-time selection between list-like and map-like printing.
       struct CIGARGenerator {
         // TODO: @fataltes --- think about just replacing this
         // with CIGAR Op class or some such.
-        std::vector<uint32_t> cigar_counts;
+        std::vector<int32_t> cigar_counts;
         std::string cigar_types;
         int32_t begin_softclip_len{0}, end_softclip_len{0};
         bool beginOverhang{false}, endOverhang{false};
@@ -409,76 +409,111 @@ Compile-time selection between list-like and map-like printing.
           beginOverhang = endOverhang = false;
         }
 
-        void add_item(uint32_t count, char type) {
+        void add_item(int32_t count, char type) {
           cigar_counts.push_back(count);
           cigar_types.push_back(type);
         }
 
-        void get_approx_cigar(int32_t readLen, std::string& cigar) {
+        // void get_approx_cigar(int32_t readLen, std::string& cigar) {
+        //   if (begin_softclip_len > 0) {
+        //     cigar += std::to_string(begin_softclip_len);
+        //     cigar += beginOverhang and allowOverhangSoftClip ? "I" : "S";
+        //   }
+        //   cigar += std::to_string(readLen - (begin_softclip_len + end_softclip_len));
+        //   cigar += "M";
+        //   if (end_softclip_len > 0) {
+        //     cigar += std::to_string(end_softclip_len);
+        //     cigar += endOverhang and allowOverhangSoftClip ? "I" : "S";
+        //   }
+        // }
+
+        // std::string get_cigar(uint32_t readLen, bool &cigar_fixed) {
+        //   cigar_fixed = false;
+        //   std::string cigar = "";
+        //   if (cigar_counts.size() != cigar_types.size() or cigar_counts.size() == 0) {
+        //     return "!";
+        //   }
+        //   if (cigar_counts.size() == 0) {
+        //     return cigar;
+        //   }
+
+        //   uint32_t cigar_length = 0;
+        //   uint32_t count = cigar_counts[0];
+
+        //   if (cigar_counts.size() == 1) {
+        //     if (count != readLen) {
+        //       count = readLen;
+        //       cigar_fixed = true;
+        //     }
+        //     cigar += std::to_string(count);
+        //     cigar += cigar_types[0];
+        //     return cigar;
+        //   }
+
+        //   char type = cigar_types[0];
+        //   if (type == 'I' or type == 'M')
+        //     cigar_length += count;
+        //   for (size_t i = 1; i < cigar_counts.size(); i++) {
+        //     if (cigar_types[i] == 'I' or cigar_types[i] == 'M')
+        //       cigar_length += cigar_counts[i];
+        //     if (type == cigar_types[i]) {
+        //       count += cigar_counts[i];
+        //     } else {
+        //       cigar += std::to_string(count);
+        //       cigar += type;
+        //       count = cigar_counts[i];
+        //       type = cigar_types[i];
+        //     }
+        //     if (i == cigar_counts.size() - 1) {
+        //       cigar += std::to_string(count);
+        //       cigar += type;
+        //       if (cigar_length < readLen) {
+        //         cigar_fixed = true;
+        //         count = readLen - cigar_length;
+        //         cigar += std::to_string(count);
+        //         cigar += 'I';
+        //       } else if (cigar_length > readLen) {
+        //         cigar_fixed = true;
+        //         count = cigar_length - readLen;
+        //         cigar += std::to_string(count);
+        //         cigar += 'I';
+        //       }
+        //     }
+        //   }
+        //   return cigar;
+        // }
+
+        std::string get_cigar() {
+          if (cigar_counts.size() == 0) return "*";
+          if (cigar_counts.size() != cigar_types.size()) return "!";
+
+          std::string cigar = "";
           if (begin_softclip_len > 0) {
             cigar += std::to_string(begin_softclip_len);
-            cigar += beginOverhang and allowOverhangSoftClip ? "I" : "S";
+            cigar += 'S';
           }
-          cigar += std::to_string(readLen - (begin_softclip_len + end_softclip_len));
-          cigar += "M";
+          // 
+          int32_t last_count = cigar_counts[0];
+          char last_type = cigar_types[0];
+          for (size_t i = 1; i < cigar_counts.size(); i++) {
+            if (cigar_types[i] == last_type) {
+              last_count += cigar_counts[i];
+            }
+            else {
+              cigar += std::to_string(last_count);
+              cigar += last_type;
+              // reset
+              last_count = cigar_counts[i];
+              last_type = cigar_types[i];
+            }
+          }
+          // add last
+          cigar += std::to_string(last_count);
+          cigar += last_type;
+          // 
           if (end_softclip_len > 0) {
             cigar += std::to_string(end_softclip_len);
-            cigar += endOverhang and allowOverhangSoftClip ? "I" : "S";
-          }
-        }
-
-        std::string get_cigar(uint32_t readLen, bool &cigar_fixed) {
-          cigar_fixed = false;
-          std::string cigar = "";
-          if (cigar_counts.size() != cigar_types.size() or cigar_counts.size() == 0) {
-            return "!";
-          }
-          if (cigar_counts.size() == 0) {
-            return cigar;
-          }
-
-          uint32_t cigar_length = 0;
-          uint32_t count = cigar_counts[0];
-
-          if (cigar_counts.size() == 1) {
-            if (count != readLen) {
-              count = readLen;
-              cigar_fixed = true;
-            }
-            cigar += std::to_string(count);
-            cigar += cigar_types[0];
-            return cigar;
-          }
-
-          char type = cigar_types[0];
-          if (type == 'I' or type == 'M')
-            cigar_length += count;
-          for (size_t i = 1; i < cigar_counts.size(); i++) {
-            if (cigar_types[i] == 'I' or cigar_types[i] == 'M')
-              cigar_length += cigar_counts[i];
-            if (type == cigar_types[i]) {
-              count += cigar_counts[i];
-            } else {
-              cigar += std::to_string(count);
-              cigar += type;
-              count = cigar_counts[i];
-              type = cigar_types[i];
-            }
-            if (i == cigar_counts.size() - 1) {
-              cigar += std::to_string(count);
-              cigar += type;
-              if (cigar_length < readLen) {
-                cigar_fixed = true;
-                count = readLen - cigar_length;
-                cigar += std::to_string(count);
-                cigar += 'I';
-              } else if (cigar_length > readLen) {
-                cigar_fixed = true;
-                count = cigar_length - readLen;
-                cigar += std::to_string(count);
-                cigar += 'I';
-              }
-            }
+            cigar += 'S';
           }
           return cigar;
         }

--- a/include/Util.hpp
+++ b/include/Util.hpp
@@ -400,7 +400,6 @@ Compile-time selection between list-like and map-like printing.
         std::vector<int32_t> cigar_counts;
         std::string cigar_types;
         int32_t begin_softclip_len{0}, end_softclip_len{0};
-        // bool allowOverhangSoftClip{false};
 
         void clear() {
           cigar_counts.clear(); cigar_types.clear();
@@ -411,75 +410,6 @@ Compile-time selection between list-like and map-like printing.
           cigar_counts.push_back(count);
           cigar_types.push_back(type);
         }
-
-        // void get_approx_cigar(int32_t readLen, std::string& cigar) {
-        //   if (begin_softclip_len > 0) {
-        //     cigar += std::to_string(begin_softclip_len);
-        //     cigar += allowOverhangSoftClip ? "I" : "S";
-        //   }
-        //   cigar += std::to_string(readLen - (begin_softclip_len + end_softclip_len));
-        //   cigar += "M";
-        //   if (end_softclip_len > 0) {
-        //     cigar += std::to_string(end_softclip_len);
-        //     cigar += allowOverhangSoftClip ? "I" : "S";
-        //   }
-        // }
-
-        // std::string get_cigar(uint32_t readLen, bool &cigar_fixed) {
-        //   cigar_fixed = false;
-        //   std::string cigar = "";
-        //   if (cigar_counts.size() != cigar_types.size() or cigar_counts.size() == 0) {
-        //     return "!";
-        //   }
-        //   if (cigar_counts.size() == 0) {
-        //     return cigar;
-        //   }
-
-        //   uint32_t cigar_length = 0;
-        //   uint32_t count = cigar_counts[0];
-
-        //   if (cigar_counts.size() == 1) {
-        //     if (count != readLen) {
-        //       count = readLen;
-        //       cigar_fixed = true;
-        //     }
-        //     cigar += std::to_string(count);
-        //     cigar += cigar_types[0];
-        //     return cigar;
-        //   }
-
-        //   char type = cigar_types[0];
-        //   if (type == 'I' or type == 'M')
-        //     cigar_length += count;
-        //   for (size_t i = 1; i < cigar_counts.size(); i++) {
-        //     if (cigar_types[i] == 'I' or cigar_types[i] == 'M')
-        //       cigar_length += cigar_counts[i];
-        //     if (type == cigar_types[i]) {
-        //       count += cigar_counts[i];
-        //     } else {
-        //       cigar += std::to_string(count);
-        //       cigar += type;
-        //       count = cigar_counts[i];
-        //       type = cigar_types[i];
-        //     }
-        //     if (i == cigar_counts.size() - 1) {
-        //       cigar += std::to_string(count);
-        //       cigar += type;
-        //       if (cigar_length < readLen) {
-        //         cigar_fixed = true;
-        //         count = readLen - cigar_length;
-        //         cigar += std::to_string(count);
-        //         cigar += 'I';
-        //       } else if (cigar_length > readLen) {
-        //         cigar_fixed = true;
-        //         count = cigar_length - readLen;
-        //         cigar += std::to_string(count);
-        //         cigar += 'I';
-        //       }
-        //     }
-        //   }
-        //   return cigar;
-        // }
 
         std::string get_cigar() {
           if (cigar_counts.size() == 0) return "*";
@@ -880,8 +810,6 @@ Compile-time selection between list-like and map-like printing.
     };
     */
 
-      // enum class PuffAlignmentMode : uint8_t { SCORE_ONLY, APPROXIMATE_CIGAR,  EXACT_CIGAR};
-
       struct AlignmentConfig {
         int32_t refExtendLength{20};
         bool fullAlignment{false};
@@ -892,7 +820,6 @@ Compile-time selection between list-like and map-like printing.
         double minScoreFraction{0.0};
         bool mimicBT2{false};
         bool mimicBT2Strict{false};
-        // bool allowOverhangSoftclip{false};
         bool allowSoftclip{false};
         bool computeCIGAR{false};
         bool end2end{true};
@@ -901,7 +828,6 @@ Compile-time selection between list-like and map-like printing.
         bool useAlignmentCache{true};
         bool noDovetail{false};
         uint32_t maxFragmentLength{1000};
-        // PuffAlignmentMode alignmentMode{PuffAlignmentMode::SCORE_ONLY};
         bool bestStrata{false};
         bool decoyPresent{false};
       };

--- a/include/Util.hpp
+++ b/include/Util.hpp
@@ -400,13 +400,11 @@ Compile-time selection between list-like and map-like printing.
         std::vector<int32_t> cigar_counts;
         std::string cigar_types;
         int32_t begin_softclip_len{0}, end_softclip_len{0};
-        bool beginOverhang{false}, endOverhang{false};
         // bool allowOverhangSoftClip{false};
 
         void clear() {
           cigar_counts.clear(); cigar_types.clear();
           begin_softclip_len = end_softclip_len = 0;
-          beginOverhang = endOverhang = false;
         }
 
         void add_item(int32_t count, char type) {
@@ -417,13 +415,13 @@ Compile-time selection between list-like and map-like printing.
         // void get_approx_cigar(int32_t readLen, std::string& cigar) {
         //   if (begin_softclip_len > 0) {
         //     cigar += std::to_string(begin_softclip_len);
-        //     cigar += beginOverhang and allowOverhangSoftClip ? "I" : "S";
+        //     cigar += allowOverhangSoftClip ? "I" : "S";
         //   }
         //   cigar += std::to_string(readLen - (begin_softclip_len + end_softclip_len));
         //   cigar += "M";
         //   if (end_softclip_len > 0) {
         //     cigar += std::to_string(end_softclip_len);
-        //     cigar += endOverhang and allowOverhangSoftClip ? "I" : "S";
+        //     cigar += allowOverhangSoftClip ? "I" : "S";
         //   }
         // }
 
@@ -488,11 +486,6 @@ Compile-time selection between list-like and map-like printing.
           if (cigar_counts.size() != cigar_types.size()) return "!";
 
           std::string cigar = "";
-          if (begin_softclip_len > 0) {
-            cigar += std::to_string(begin_softclip_len);
-            cigar += 'S';
-          }
-          // 
           int32_t last_count = cigar_counts[0];
           char last_type = cigar_types[0];
           for (size_t i = 1; i < cigar_counts.size(); i++) {
@@ -510,11 +503,6 @@ Compile-time selection between list-like and map-like printing.
           // add last
           cigar += std::to_string(last_count);
           cigar += last_type;
-          // 
-          if (end_softclip_len > 0) {
-            cigar += std::to_string(end_softclip_len);
-            cigar += 'S';
-          }
           return cigar;
         }
       };

--- a/include/Util.hpp
+++ b/include/Util.hpp
@@ -908,6 +908,7 @@ Compile-time selection between list-like and map-like printing.
         // bool allowSoftclip{false};
         bool computeCIGAR{false};
         bool end2end{false};
+        double maxSoftclipFraction{0.2};
         uint32_t endBonus{5};
         bool useAlignmentCache{true};
         bool noDovetail{false};

--- a/include/Util.hpp
+++ b/include/Util.hpp
@@ -907,6 +907,8 @@ Compile-time selection between list-like and map-like printing.
         // bool allowOverhangSoftclip{false};
         // bool allowSoftclip{false};
         bool computeCIGAR{false};
+        bool end2end{false};
+        uint32_t endBonus{5};
         bool useAlignmentCache{true};
         bool noDovetail{false};
         uint32_t maxFragmentLength{1000};

--- a/include/Util.hpp
+++ b/include/Util.hpp
@@ -1369,15 +1369,17 @@ Compile-time selection between list-like and map-like printing.
 
         struct AlignmentResult {
             AlignmentResult(bool isFwIn, int32_t scoreIn, std::string cigarIn, uint32_t openGapLenIn, 
-                            uint16_t softclip_start_in ) :
-                    isFw(isFwIn), score(scoreIn), cigar(cigarIn), openGapLen(openGapLenIn), softclip_start(softclip_start_in) {}
+                            uint16_t softclip_start_in, uint16_t softclip_end_in ) :
+                    isFw(isFwIn), score(scoreIn), cigar(cigarIn), openGapLen(openGapLenIn), softclip_start(softclip_start_in),
+                    softclip_end(softclip_end_in) {}
 
-            AlignmentResult() : isFw(true), score(0), cigar(""), openGapLen(0), softclip_start(0) {}
+            AlignmentResult() : isFw(true), score(0), cigar(""), openGapLen(0), softclip_start(0), softclip_end(0) {}
             bool isFw;
             int32_t score;
             std::string cigar;
             uint32_t openGapLen;
             uint16_t softclip_start{0};
+            uint16_t softclip_end{0};
         };
 
       void joinReadsAndFilterSingle( pufferfish::util::CachedVectorMap<size_t, std::vector<pufferfish::util::MemCluster>, std::hash<size_t>>& leftMemClusters,

--- a/include/Util.hpp
+++ b/include/Util.hpp
@@ -823,7 +823,8 @@ Compile-time selection between list-like and map-like printing.
         bool allowSoftclip{false};
         bool computeCIGAR{false};
         bool end2end{true};
-        double maxSoftclipFraction{0.2};
+        double maxSoftclipFractionGeneral{0.2};
+        double maxSoftclipFractionOverhang{0.2};
         uint32_t endBonus{5};
         bool useAlignmentCache{true};
         bool noDovetail{false};

--- a/include/Util.hpp
+++ b/include/Util.hpp
@@ -892,7 +892,7 @@ Compile-time selection between list-like and map-like printing.
     };
     */
 
-      enum class PuffAlignmentMode : uint8_t { SCORE_ONLY, APPROXIMATE_CIGAR,  EXACT_CIGAR};
+      // enum class PuffAlignmentMode : uint8_t { SCORE_ONLY, APPROXIMATE_CIGAR,  EXACT_CIGAR};
 
       struct AlignmentConfig {
         int32_t refExtendLength{20};
@@ -904,12 +904,13 @@ Compile-time selection between list-like and map-like printing.
         double minScoreFraction{0.0};
         bool mimicBT2{false};
         bool mimicBT2Strict{false};
-        bool allowOverhangSoftclip{false};
-        bool allowSoftclip{false};
+        // bool allowOverhangSoftclip{false};
+        // bool allowSoftclip{false};
+        bool computeCIGAR{false};
         bool useAlignmentCache{true};
         bool noDovetail{false};
         uint32_t maxFragmentLength{1000};
-        PuffAlignmentMode alignmentMode{PuffAlignmentMode::SCORE_ONLY};
+        // PuffAlignmentMode alignmentMode{PuffAlignmentMode::SCORE_ONLY};
         bool bestStrata{false};
         bool decoyPresent{false};
       };

--- a/include/ksw2pp/KSW2Aligner.hpp
+++ b/include/ksw2pp/KSW2Aligner.hpp
@@ -38,7 +38,7 @@ struct KSW2Config {
   int dropoff = -1;
   int flag = 0;
   int alphabetSize = 5;
-  int end_bonus = 10;
+  int end_bonus = 5;
   KSW2AlignmentType atype = KSW2AlignmentType::GLOBAL;
 };
 

--- a/include/ksw2pp/KSW2Aligner.hpp
+++ b/include/ksw2pp/KSW2Aligner.hpp
@@ -66,7 +66,7 @@ public:
 
   int operator()(const char* const queryOriginal, const int queryLength,
                  const char* const targetOriginal, const int targetLength,
-                 ksw_extz_t* ez, int cutoff, EnumToType<KSW2AlignmentType::EXTENSION>);
+                 ksw_extz_t* ez, int cutoff, int maxSoftclip, EnumToType<KSW2AlignmentType::EXTENSION>);
 
   int operator()(const uint8_t* const queryOriginal, const int queryLength,
                  const uint8_t* const targetOriginal, const int targetLength,
@@ -74,7 +74,7 @@ public:
 
   int operator()(const uint8_t* const queryOriginal, const int queryLength,
                  const uint8_t* const targetOriginal, const int targetLength,
-                 ksw_extz_t* ez, int cutoff, EnumToType<KSW2AlignmentType::EXTENSION>);
+                 ksw_extz_t* ez, int cutoff, int maxSoftclip, EnumToType<KSW2AlignmentType::EXTENSION>);
 
   /**
    * Variants of the operator that do not require an output

--- a/include/ksw2pp/ksw2.h
+++ b/include/ksw2pp/ksw2.h
@@ -57,11 +57,11 @@ void ksw_extz(void *km, int qlen, const uint8_t *query, int tlen, const uint8_t 
 			  int8_t q, int8_t e, int w, int zdrop, int flag, ksw_extz_t *ez);
 
 void ksw_extz2_sse(/*unsigned int simd, */void *km, int qlen, const uint8_t *query, int tlen, const uint8_t *target, int8_t m, const int8_t *mat,
-				   int8_t q, int8_t e, int w, int zdrop, int end_bonus, int flag, ksw_extz_t *ez, int cutoff);
+				   int8_t q, int8_t e, int w, int zdrop, int end_bonus, int flag, ksw_extz_t *ez, int cutoff, int max_sc_len);
 void ksw_extz2_sse41(/*unsigned int simd, */void *km, int qlen, const uint8_t *query, int tlen, const uint8_t *target, int8_t m, const int8_t *mat,
-           int8_t q, int8_t e, int w, int zdrop, int end_bonus, int flag, ksw_extz_t *ez, int cutoff);
+           int8_t q, int8_t e, int w, int zdrop, int end_bonus, int flag, ksw_extz_t *ez, int cutoff, int max_sc_len);
 void ksw_extz2_sse2(/*unsigned int simd, */void *km, int qlen, const uint8_t *query, int tlen, const uint8_t *target, int8_t m, const int8_t *mat,
-           int8_t q, int8_t e, int w, int zdrop, int end_bonus, int flag, ksw_extz_t *ez, int cutoff);
+           int8_t q, int8_t e, int w, int zdrop, int end_bonus, int flag, ksw_extz_t *ez, int cutoff, int max_sc_len);
 
 
 void ksw_extd(void *km, int qlen, const uint8_t *query, int tlen, const uint8_t *target, int8_t m, const int8_t *mat,

--- a/src/PuffAligner.cpp
+++ b/src/PuffAligner.cpp
@@ -574,7 +574,7 @@ bool PuffAligner::alignRead(std::string& read, std::string& read_rc, const std::
           //     computeCIGAR ? addCigar(cigarGen, ez, true) : firstMemStart_read - num_soft_clipped;
 
           decltype(alignmentScore) part_score = ez.max;
-          if(ez.mqe + aligner_config.end_bonus > ez.max)
+          if(mopts.end2end || ez.mqe + aligner_config.end_bonus > ez.max)
           {
             part_score = ez.mqe;
             // openGapLen = readWindow.length();
@@ -835,7 +835,7 @@ bool PuffAligner::alignRead(std::string& read, std::string& read_rc, const std::
           // }
 
           decltype(alignmentScore) part_score = ez.max;
-          if(ez.mqe + aligner_config.end_bonus > ez.max)
+          if(mopts.end2end || ez.mqe + aligner_config.end_bonus > ez.max)
           {
             part_score = ez.mqe;
           }

--- a/src/PuffAligner.cpp
+++ b/src/PuffAligner.cpp
@@ -486,8 +486,8 @@ bool PuffAligner::alignRead(std::string& read, std::string& read_rc, const std::
                   ksw2pp::EnumToType<ksw2pp::KSW2AlignmentType::EXTENSION>());
           logger_->debug("\t\t\tksw2_results:");
           logger_->debug("\t\t\t\tmax={}, max_q={}, max_t={}", ez.max, ez.max_q, ez.max_t);
-          logger_->debug("\t\t\t\tmqe_score={}, mqe_t={}", ez.mqe, ez.mqe_t);
-          logger_->debug("\t\t\t\tmte_score={}, mte_q={}", ez.mte, ez.mte_q);
+          logger_->debug("\t\t\t\tmqe={}, mqe_t={}", ez.mqe, ez.mqe_t);
+          logger_->debug("\t\t\t\tmte={}, mte_q={}", ez.mte, ez.mte_q);
           logger_->debug("\t\t\t\tstopped={}, reach_end={}, zdropped={}, score={}", ez.stopped == 1, ez.reach_end == 1, ez.zdropped == 1, ez.score);
           if(computeCIGAR) {
             std::string tmp_cg_exp;
@@ -573,7 +573,8 @@ bool PuffAligner::alignRead(std::string& read, std::string& read_rc, const std::
           if(ez.mqe + aligner_config.end_bonus > ez.max)
           {
             part_score = ez.mqe;
-            openGapLen = readWindow.length();
+            // openGapLen = readWindow.length();
+            openGapLen = ez.mqe_t + 1;
           }
           else
           {
@@ -772,8 +773,8 @@ bool PuffAligner::alignRead(std::string& read, std::string& read_rc, const std::
                   ksw2pp::EnumToType<ksw2pp::KSW2AlignmentType::EXTENSION>());
           logger_->debug("\t\t\tksw2_results:");
           logger_->debug("\t\t\t\tmax={}, max_q={}, max_t={}", ez.max, ez.max_q, ez.max_t);
-          logger_->debug("\t\t\t\tmqe_score={}, mqe_t={}", ez.mqe, ez.mqe_t);
-          logger_->debug("\t\t\t\tmte_score={}, mte_q={}", ez.mte, ez.mte_q);
+          logger_->debug("\t\t\t\tmqe={}, mqe_t={}", ez.mqe, ez.mqe_t);
+          logger_->debug("\t\t\t\tmte={}, mte_q={}", ez.mte, ez.mte_q);
           logger_->debug("\t\t\t\tstopped={}, reach_end={}, zdropped={}, score={}", ez.stopped == 1, ez.reach_end == 1, ez.zdropped == 1, ez.score);
           if(computeCIGAR) {
             std::string tmp_cg_exp;

--- a/src/PuffAligner.cpp
+++ b/src/PuffAligner.cpp
@@ -375,6 +375,10 @@ bool PuffAligner::alignRead(std::string& read, std::string& read_rc, const std::
       hctr.skippedAlignments_byCache += 1;
       arOut.score = hit->second.score;
       if (mopts.computeCIGAR) { arOut.cigar = hit->second.cigar; }
+      if (mopts.allowSoftclip) {
+        arOut.softclip_start = hit->second.softclip_start;
+        arOut.softclip_end = hit->second.softclip_end;
+      }
       arOut.openGapLen = hit->second.openGapLen;
       return true;
     }
@@ -795,6 +799,10 @@ bool PuffAligner::alignRead(std::string& read, std::string& read_rc, const std::
     aln.isFw = isFw;
     aln.score = alignmentScore;
     if (mopts.computeCIGAR) { aln.cigar = cigar; }
+    if (mopts.allowSoftclip) {
+      aln.softclip_start = arOut.softclip_start;
+      aln.softclip_end = arOut.softclip_end;
+    }
     aln.openGapLen = openGapLen;
     alnCache[hashKey] = aln;
   }

--- a/src/PuffAligner.cpp
+++ b/src/PuffAligner.cpp
@@ -229,6 +229,8 @@ bool PuffAligner::alignRead(std::string& read, std::string& read_rc, const std::
   auto& cigarGen = cigarGen_;
   cigarGen.clear();
 
+  ksw_reset_extz(&ez);
+
   // where this reference starts, and its length.
   int64_t refAccPos = tid > 0 ? refAccumLengths[tid - 1] : 0;
   int64_t refTotalLength = refAccumLengths[tid] - refAccPos;
@@ -606,7 +608,6 @@ bool PuffAligner::alignRead(std::string& read, std::string& read_rc, const std::
         }
 
         if (readWindow.length() <= minLengthGapRequired and gapRead == gapRef) {
-          // EHSAN-TODO: add debug info here
           logger_->debug("\t\t\t\taligning with align_ungapped (readWindow.length()={} < minLengthGapRequired={})", readWindow.length(), minLengthGapRequired);
           score += align_ungapped(readWindow.data(), refSeq1, gapRead);
         } else {

--- a/src/PuffAligner.cpp
+++ b/src/PuffAligner.cpp
@@ -591,7 +591,8 @@ bool PuffAligner::alignRead(std::string& read, std::string& read_rc, const std::
           {
             part_score = ez.max;
             openGapLen = ez.max_t + 1;
-            cigarGen.begin_softclip_len = readWindow.length() - (ez.max_q + 1);
+            cigarGen.add_item(readWindow.length() - (ez.max_q + 1), 'S');
+
           }
           alignmentScore += part_score;
           addCigar(cigarGen, ez, true);
@@ -613,8 +614,7 @@ bool PuffAligner::alignRead(std::string& read, std::string& read_rc, const std::
 
           if (mopts.computeCIGAR) {
             if (allowSoftclip && remainedSoftClipLen >= 0) {
-              cigarGen.begin_softclip_len = firstMemStart_read;
-              cigarGen.beginOverhang = true;
+              cigarGen.add_item(firstMemStart_read, 'S');
               openGapLen = 0;
             } else {
               cigarGen.add_item(firstMemStart_read, 'I');
@@ -860,7 +860,7 @@ bool PuffAligner::alignRead(std::string& read, std::string& read_rc, const std::
           else
           {
             part_score = ez.max;
-            cigarGen.end_softclip_len = readWindow.length() - (ez.max_q + 1);
+            cigarGen.add_item(readWindow.length() - (ez.max_q + 1), 'S');
           }
           alignmentScore += part_score;
           addCigar(cigarGen, ez, false);
@@ -885,8 +885,7 @@ bool PuffAligner::alignRead(std::string& read, std::string& read_rc, const std::
                      -1 * mopts.gapExtendPenalty * readWindow.length());
           if (mopts.computeCIGAR) {
             if (allowSoftclip && remainedSoftClipLen >= 0) {
-              cigarGen.end_softclip_len = readWindow.length();
-              cigarGen.endOverhang = true;
+              cigarGen.add_item(readWindow.length(), 'S');
             } else {
               cigarGen.add_item(readWindow.length(), 'I');
             }

--- a/src/PuffAligner.cpp
+++ b/src/PuffAligner.cpp
@@ -972,6 +972,8 @@ int32_t PuffAligner::calculateAlignments(std::string& read_left, std::string& re
         auto& orphan_aln_cache = isLeft ? alnCacheLeft : alnCacheRight;
 
         ar_orphan.score = invalidScore;
+        ar_orphan.softclip_start = 0;
+        ar_orphan.softclip_end = 0;
         alignRead(read_orphan, rc_orphan, jointHit.orphanClust()->mems, jointHit.orphanClust()->queryChainHash,
                   jointHit.orphanClust()->perfectChain,
                   jointHit.orphanClust()->isFw, tid, orphan_aln_cache, hctr, ar_orphan, verbose);
@@ -989,6 +991,8 @@ int32_t PuffAligner::calculateAlignments(std::string& read_left, std::string& re
     } else {
         hctr.totalAlignmentAttempts += 2;
         ar_left.score = ar_right.score = invalidScore;
+        ar_left.softclip_start = ar_right.softclip_start = 0;
+        ar_left.softclip_end = ar_right.softclip_end = 0;
         if (verbose) { std::cerr << "left\n"; }
         alignRead(read_left, read_left_rc_, jointHit.leftClust->mems, jointHit.leftClust->queryChainHash, jointHit.leftClust->perfectChain,
                                             jointHit.leftClust->isFw, tid, alnCacheLeft, hctr, ar_left, verbose);
@@ -1045,6 +1049,8 @@ int32_t PuffAligner::calculateAlignments(std::string& read, pufferfish::util::Jo
 
     hctr.totalAlignmentAttempts += 1;
     ar_left.score = invalidScore;
+    ar_left.softclip_start = 0;
+    ar_left.softclip_end = 0;
     const auto& oc = jointHit.orphanClust();
     alignRead(read, read_left_rc_, oc->mems, oc->queryChainHash, oc->perfectChain, oc->isFw, tid, alnCacheLeft, hctr, ar_left, verbose);
     auto total_softclip_len = ar_left.softclip_start + ar_left.softclip_end;

--- a/src/PuffAligner.cpp
+++ b/src/PuffAligner.cpp
@@ -617,14 +617,17 @@ bool PuffAligner::alignRead(std::string& read, std::string& read_rc, const std::
                      -1 * mopts.gapExtendPenalty * firstMemStart_read);
           openGapLen = firstMemStart_read;
 
+          char cigar_char;
+          if (allowSoftclip && remainedSoftClipLen >= numSoftClipped) {
+            cigar_char = 'S';
+            openGapLen = 0;
+          } else {
+            cigar_char = 'I';
+            numSoftClipped = 0;
+          }
+
           if (mopts.computeCIGAR) {
-            if (allowSoftclip && remainedSoftClipLen >= numSoftClipped) {
-              cigarGen.add_item(firstMemStart_read, 'S');
-              openGapLen = 0;
-            } else {
-              cigarGen.add_item(firstMemStart_read, 'I');
-              numSoftClipped = 0;
-            }
+            cigarGen.add_item(firstMemStart_read, cigar_char);
           }
         }
         arOut.softclip_start = numSoftClipped;
@@ -786,7 +789,7 @@ bool PuffAligner::alignRead(std::string& read, std::string& read_rc, const std::
         auto readWindow = readView.substr(prevMemEnd_read + 1).to_string();
         fillRefSeqBuffer(allRefSeq, refAccPos, refTailStart, refLen, refSeqBuffer_);
 
-        int32_t numSoftClipped = 0;
+        int32_t numSoftClipped = 0; 
 
         logger_->debug("\t\t\tgapRead : {}, refLen : {}, refBuffer_.size() : {}, refTotalLength : {}", gapRead, refLen, refSeqBuffer_.size(), refTotalLength);
         if (refLen > 0) {
@@ -897,13 +900,17 @@ bool PuffAligner::alignRead(std::string& read, std::string& read_rc, const std::
                   ? 0
                   : (-1 * mopts.gapOpenPenalty +
                      -1 * mopts.gapExtendPenalty * readWindow.length());
+
+          char cigar_char;
+          if (allowSoftclip && remainedSoftClipLen >= numSoftClipped) {
+            cigar_char = 'S';
+          } else {
+            cigar_char = 'I';
+            numSoftClipped = 0;
+          }
+
           if (mopts.computeCIGAR) {
-            if (allowSoftclip && remainedSoftClipLen >= numSoftClipped) {
-              cigarGen.add_item(readWindow.length(), 'S');
-            } else {
-              cigarGen.add_item(readWindow.length(), 'I');
-              numSoftClipped = 0;
-            }
+            cigarGen.add_item(readWindow.length(), cigar_char);
           }
         }
         arOut.softclip_end = numSoftClipped;

--- a/src/PuffAligner.cpp
+++ b/src/PuffAligner.cpp
@@ -139,13 +139,79 @@ int32_t PuffAligner::align_ungapped(const char* const query, const char* const t
   return score;
 }
 
+std::string collapse_cigar(std::string exp_cigar)
+{
+  if(exp_cigar.size() < 1) return "";
+  std::string collapsed = "";
+  char last_char = exp_cigar[0];
+  int cnt = 1;
+  for(unsigned int i = 1; i < exp_cigar.size(); i++)
+  {
+    if(exp_cigar[i] == last_char)
+    {
+      cnt++;
+    }
+    else
+    {
+      collapsed += std::to_string(cnt) + last_char;
+      // printf("%d%c", cnt, last_char);
+      last_char = exp_cigar[i];
+      cnt = 1;
+    }
+  }
+  collapsed += std::to_string(cnt) + last_char;
+  return collapsed;
+}
+
+std::string ksw2_to_cigar(const char *qseq, const char *tseq, ksw_extz_t *ez, std::string &exp_cigar)
+{
+  int qpos = 0;
+  int tpos = 0;
+  std::string cigar = "";
+  exp_cigar = "";
+  if (ez->n_cigar > 0) {
+    for (int i = 0; i < ez->n_cigar; ++i)
+    {
+      if((ez->cigar[i]&0xf) == 1)
+      {
+        qpos += ez->cigar[i]>>4;
+        exp_cigar += std::string(ez->cigar[i]>>4, 'I');
+      }
+      else if ((ez->cigar[i]&0xf) == 2)
+      {
+        tpos += ez->cigar[i]>>4;
+        exp_cigar += std::string(ez->cigar[i]>>4, 'D');
+      }
+      else
+      {
+        for(unsigned int j = 0; j < ez->cigar[i]>>4; j++)
+        {
+          // printf("tpos:%d qpos:%d %c %c\n", tpos, qpos, tseq[tpos], qseq[qpos]);
+          if(tseq[tpos] == qseq[qpos])
+            exp_cigar += '=';
+          else
+            exp_cigar += 'X';
+          tpos++;
+          qpos++;
+        }
+      }
+      cigar += std::to_string(ez->cigar[i]>>4) + "MID"[ez->cigar[i]&0xf];
+      // printf("%d%c", ez->cigar[i]>>4, "MID"[ez->cigar[i]&0xf]);
+    }
+    // putchar('\t');
+    // collapse_cigar(exp_cigar);
+  }
+  return cigar;
+}
+
 /**
  *  Align the read `original_read`, whose mems consist of `mems` against the index and return the result
  *  in `arOut`.  How the alignment is computed (i.e. full vs between-mem and CIGAR vs. score only) depends
  *  on the parameters of how this PuffAligner object was constructed.
  **/
-bool PuffAligner::alignRead(std::string& read, std::string& read_rc, const std::vector<pufferfish::util::MemInfo> &mems, uint64_t queryChainHash, bool perfectChain,
-                            bool isFw, size_t tid, AlnCacheMap &alnCache, HitCounters &hctr, AlignmentResult& arOut, bool /*verbose*/) {
+bool PuffAligner::alignRead(std::string& read, std::string& read_rc, const std::vector<pufferfish::util::MemInfo> &mems, 
+                            uint64_t queryChainHash, bool perfectChain, bool isFw, size_t tid, AlnCacheMap &alnCache, 
+                            HitCounters &hctr, AlignmentResult& arOut, bool /*verbose*/) {
 
   int32_t alignmentScore{std::numeric_limits<decltype(arOut.score)>::min()};
   if (mems.empty()) {
@@ -169,8 +235,7 @@ bool PuffAligner::alignRead(std::string& read, std::string& read_rc, const std::
   auto& cigarGen = cigarGen_;
   cigarGen.clear();
 
-  std::string cigar = "";
-  ksw_reset_extz(&ez);
+  ksw_reset_extz(&ez); // EHSAN: Do we even need to reset here? It's being reset either in the wrapper or in ksw2 itself, no?
 
   // where this reference starts, and its length.
   int64_t refAccPos = tid > 0 ? refAccumLengths[tid - 1] : 0;
@@ -181,17 +246,20 @@ bool PuffAligner::alignRead(std::string& read, std::string& read_rc, const std::
   auto memlen = frontMem.extendedlen;
   auto readLen = read.length();
   auto tpos = frontMem.tpos;
-
+  
+  auto logger_ = spdlog::get("console");
+  // spdlog::set_level(spdlog::level::debug); // Set global log level to debug
+  // logger_->set_pattern("%v");
 
   if (perfectChain) {
-    arOut.score = alignmentScore = readLen * mopts.matchScore;
-    if (computeCIGAR) { cigarGen.add_item(readLen, 'M'); }
+    logger_->debug("\t\tperfect chain!");
+    // SPDLOG_DEBUG(logger_,"[[");
+    // SPDLOG_DEBUG(logger_,"read sequence ({}) : {}", (isFw ? "FW" : "RC"), readView);
+    // SPDLOG_DEBUG(logger_,"ref  sequence      : {}", (doFullAlignment ? tseq : refSeqBuffer_));
+    // SPDLOG_DEBUG(logger_,"perfect chain!\n]]\n");
     hctr.skippedAlignments_byCov += 1;
-    SPDLOG_DEBUG(logger_,"[[");
-    SPDLOG_DEBUG(logger_,"read sequence ({}) : {}", (isFw ? "FW" : "RC"), readView);
-    SPDLOG_DEBUG(logger_,"ref  sequence      : {}", (doFullAlignment ? tseq : refSeqBuffer_));
-    SPDLOG_DEBUG(logger_,"perfect chain!\n]]\n");
-    arOut.cigar = cigar;
+    arOut.score = alignmentScore = readLen * mopts.matchScore;
+    arOut.cigar = (computeCIGAR ? std::to_string(readLen) + 'M' : "");
     arOut.openGapLen = openGapLen;
     return true;
   }
@@ -206,7 +274,7 @@ bool PuffAligner::alignRead(std::string& read, std::string& read_rc, const std::
   currHitStart_read = isFw ? rpos : readLen - (rpos + memlen);
 
   if (currHitStart_read < 0 or currHitStart_read >= (int32_t) readLen) {
-    std::cerr << "[ERROR in PuffAligner::alignRead :] currHitStart_read is invalid; this hould not happen!\n";
+    std::cerr << "[ERROR in PuffAligner::alignRead :] currHitStart_read is invalid; this should not happen!\n";
     return false;
   }
 
@@ -240,8 +308,10 @@ bool PuffAligner::alignRead(std::string& read, std::string& read_rc, const std::
   }
 
   auto& bandwidth = aligner.config().bandwidth;
+  auto& aligner_config = aligner.config();
   libdivide::divider<int32_t> gapExtDivisor(static_cast<int32_t>(mopts.gapExtendPenalty));
   const int32_t minAcceptedScore = scoreStatus_.getCutoff(read.length()); //mopts.minScoreFraction * mopts.matchScore * readLen;
+  logger_->debug("\t\tNOTE mems.size(): {}, isRev: {}, minAcceptedScore: {}", mems.size(), !isFw, minAcceptedScore);
   // compute the maximum gap length that would be allowed given the length of read aligned so far and the current 
   // alignment score.
   auto maxAllowedGaps = [&minAcceptedScore, &readLen, &gapExtDivisor, this] (uint32_t alignedLen, int32_t alignmentScore) -> int {
@@ -293,26 +363,28 @@ bool PuffAligner::alignRead(std::string& read, std::string& read_rc, const std::
     keyLen = (static_cast<int64_t>(refStart + remLen + refExtLength) < refTotalLength) ? remLen + refExtLength : refTotalLength - refStart;
   }
 
-
   fillRefSeqBuffer(allRefSeq, refAccPos, refStart, keyLen, refSeqBuffer_);
   // int32_t originalRefSeqLen = static_cast<int32_t>(refSeqBuffer_.length());
   // If we're not using fullAlignment, we'll need the full reference sequence later
   // so copy it into tseq.
   if (!doFullAlignment) { tseq = refSeqBuffer_; }
 
-  bool useAlnCache = mopts.useAlignmentCache and isMultimapping_ and !perfectChain and !overhangingEnd;
+  // bool useAlnCache = mopts.useAlignmentCache and isMultimapping_ and !perfectChain and !overhangingEnd;
+  bool useAlnCache = mopts.useAlignmentCache and isMultimapping_ and !overhangingEnd; // EHSAN: we're sure that it's not a perfectChain
 
   // first, check if we can skip this by perfect chaining
   // if not, check if we can skip it via the alignment cache
-  if (perfectChain) {
-    arOut.score = alignmentScore = readLen * mopts.matchScore;
-    if (computeCIGAR or approximateCIGAR) { cigarGen.add_item(readLen, 'M'); }
-    hctr.skippedAlignments_byCov += 1;
-    /*SPDLOG_DEBUG(logger_,"[[");
-    SPDLOG_DEBUG(logger_,"read sequence ({}) : {}", (isFw ? "FW" : "RC"), readView);
-    SPDLOG_DEBUG(logger_,"ref  sequence      : {}", (doFullAlignment ? tseq : refSeqBuffer_));
-    SPDLOG_DEBUG(logger_,"perfect chain!\n]]\n");*/
-  } else if (useAlnCache and !alnCache.empty()) { //  and !overhangingStart) {
+  // if (perfectChain) { // EHSAN: this was taken care of before
+  //   arOut.score = alignmentScore = readLen * mopts.matchScore;
+  //   if (computeCIGAR or approximateCIGAR) { cigarGen.add_item(readLen, 'M'); }
+  //   hctr.skippedAlignments_byCov += 1;
+  //   /*SPDLOG_DEBUG(logger_,"[[");
+  //   SPDLOG_DEBUG(logger_,"read sequence ({}) : {}", (isFw ? "FW" : "RC"), readView);
+  //   SPDLOG_DEBUG(logger_,"ref  sequence      : {}", (doFullAlignment ? tseq : refSeqBuffer_));
+  //   SPDLOG_DEBUG(logger_,"perfect chain!\n]]\n");*/
+  // } else 
+  if (useAlnCache and !alnCache.empty()) { //  and !overhangingStart) {
+    logger_->debug("\t\tNOTE checking cache");
     // mopts.useAlignmentCache and !alnCache.empty() and isMultimapping_ and !overhangingEnd) { //  and !overhangingStart) {
     // hash the reference string
     MetroHash64::Hash(reinterpret_cast<uint8_t *>(const_cast<char*>(refSeqBuffer_.data())), keyLen, reinterpret_cast<uint8_t *>(&hashKey), 0);
@@ -322,24 +394,24 @@ bool PuffAligner::alignRead(std::string& read, std::string& read_rc, const std::
     auto hit = alnCache.find(hashKey);
     // if so, we know the alignment score
     if (hit != alnCache.end() and (isFw == hit->second.isFw) ) {//}and refStart + readLen + refExtLength < refTotalLength) {
+      logger_->debug("\t\tNOTE cache hit... done!");
       hctr.skippedAlignments_byCache += 1;
       arOut.score = hit->second.score;
       if (computeCIGAR or approximateCIGAR) { arOut.cigar = hit->second.cigar; }
       arOut.openGapLen = hit->second.openGapLen;
       return true;
     }
+    logger_->debug("\t\tNOTE cache miss... continue");
   }
-
-  //auto logger_ = spdlog::get("console");
-  //spdlog::set_level(spdlog::level::debug); // Set global log level to debug
-  //logger_->set_pattern("%v");
 
   // @mohsen & @fataltes --- we should figure out how to
   // avoid computing the rc of a read if we've already done it.
   if (!isFw and read_rc.empty()) { read_rc = pufferfish::util::reverseComplement(read); }
   nonstd::string_view readView = (isFw) ? read : read_rc;
 
-  if (!perfectChain) {
+  logger_->debug("\t\t+++ NEXT MEM readPos: {}, refPos: {}, memLen: {}", (isFw ? rpos : readLen - (rpos + memlen)), tpos, memlen);
+
+  // if (!perfectChain) { EHSAN: No need to check this because it has been checked before
     // NOTE: We don't worry about soft clipping within the `doFullAlignment`
     // branch, since these two options are currently incompatible.
     if (doFullAlignment) {
@@ -359,13 +431,8 @@ bool PuffAligner::alignRead(std::string& read, std::string& read_rc, const std::
       alignmentScore =
           allowOverhangSoftclip ? std::max(ez.mqe, ez.mte) : ez.mqe;
 
-      SPDLOG_DEBUG(logger_,
-                   "readSeq : {}\nrefSeq  : {}\nscore   : {}\nreadStart : {}",
-                   readSeq, refSeqBuffer_, alignmentScore, readStart);
-      SPDLOG_DEBUG(
-          logger_,
-          "currHitStart_read : {}, currHitStart_ref : {}\nmqe : {}, mte : {}\n",
-          currHitStart_read, currHitStart_ref, ez.mqe, ez.mte);
+      logger_->debug("readSeq : {}\nrefSeq  : {}\nscore   : {}\nreadStart : {}", readSeq, refSeqBuffer_, alignmentScore, readStart);
+      logger_->debug("currHitStart_read : {}, currHitStart_ref : {}\nmqe : {}, mte : {}\n", currHitStart_read, currHitStart_ref, ez.mqe, ez.mte);
 
       if (computeCIGAR) {
         openGapLen = addCigar(cigarGen, ez, false);
@@ -379,15 +446,14 @@ bool PuffAligner::alignRead(std::string& read, std::string& read_rc, const std::
       alignmentScore = 0;
 
       // std::stringstream ss;
-      SPDLOG_DEBUG(logger_, "[[");
-      SPDLOG_DEBUG(logger_, "read sequence ({}) : {}", (isFw ? "FW" : "RC"),
-                   readView);
-      SPDLOG_DEBUG(logger_, "ref  sequence      : {}\nrefID : {}", tseq, tid);
+      logger_->debug("\t\tread sequence ({}) : {}", (isFw ? "FW" : "RC"), readView);
+      logger_->debug("\t\tref  sequence      : {}", tseq);
 
       // If the first mem does not start at the beginning of the
       // read, then there is a gap to align.
       int32_t firstMemStart_read = (isFw) ? rpos : readLen - (rpos + memlen);
       if (firstMemStart_read > 0) {
+        logger_->debug("\t\t### EXTEND LEFT");
         // align the part before the first mem
 
         // the gap is of length firstMemStart_read, so grab that much (plus
@@ -404,20 +470,30 @@ bool PuffAligner::alignRead(std::string& read, std::string& read_rc, const std::
                                 refWindowLength, refSeqBuffer_);
 
         if (refSeqBuffer_.length() > 0) {
+          logger_->debug("\t\t\tCASE 1: some reference bases left to align");
           auto readWindow = std::string(readView.substr(0, firstMemStart_read));
           std::reverse(readWindow.begin(), readWindow.end());
-          SPDLOG_DEBUG(logger_,
-                       "PRE:\nreadStartPosOnRef : {}\nrefWindowStart : {}",
-                       readStartPosOnRef, refWindowStart);
-          SPDLOG_DEBUG(logger_, "refWindowLength : {}\nread : [{}]\nref : [{}]",
-                       refWindowLength, readWindow, refSeqBuffer_);
+          logger_->debug("\t\t\treadStartPosOnRef: {}\trefWindowStart: {}\trefWindowLength: {}", readStartPosOnRef, refWindowStart, refWindowLength);
+          logger_->debug("\t\t\tread: [{}]", readWindow);
+          logger_->debug("\t\t\tref:  [{}]", refSeqBuffer_);
           
           ksw_reset_extz(&ez);
           bandwidth = maxAllowedGaps(0, 0) + 1;
+          logger_->debug("\t\t\tksw2_parameters: bandwidth={}, end_bonus={}, zdrop={}", bandwidth, aligner_config.end_bonus, aligner_config.dropoff);
           auto cutoff = minAcceptedScore - mopts.matchScore * read.length();
           aligner(readWindow.data(), readWindow.length(), refSeqBuffer_.data(),
                   refSeqBuffer_.length(), &ez, cutoff,
                   ksw2pp::EnumToType<ksw2pp::KSW2AlignmentType::EXTENSION>());
+          logger_->debug("\t\t\tksw2_results:");
+          logger_->debug("\t\t\t\tmax={}, max_q={}, max_t={}", ez.max, ez.max_q, ez.max_t);
+          logger_->debug("\t\t\t\tmqe_score={}, mqe_t={}", ez.mqe, ez.mqe_t);
+          logger_->debug("\t\t\t\tmte_score={}, mte_q={}", ez.mte, ez.mte_q);
+          logger_->debug("\t\t\t\tstopped={}, reach_end={}, zdropped={}, score={}", ez.stopped == 1, ez.reach_end == 1, ez.zdropped == 1, ez.score);
+          if(computeCIGAR) {
+            std::string tmp_cg_exp;
+            logger_->debug("\t\t\t\talnCigar: {}", ksw2_to_cigar(readWindow.c_str(), refSeqBuffer_.c_str(), &ez, tmp_cg_exp));
+            logger_->debug("\t\t\t\talnCigar: {}", collapse_cigar(tmp_cg_exp));
+          } 
           if (ez.stopped) hctr.skippedAlignments_notAlignable += 1;
           if (ez.mqe != KSW_NEG_INF and ez.stopped>0) ez.stopped = 0;
 
@@ -432,48 +508,48 @@ bool PuffAligner::alignRead(std::string& read, std::string& read_rc, const std::
           // simply deleting the rest of the read
           //int32_t delCost = (-1 * mopts.gapOpenPenalty +
           //                   -1 * mopts.gapExtendPenalty * readWindow.length());
-          decltype(alignmentScore) part_score = ez.mqe;//std::max(delCost, ez.mqe);
-          int32_t num_soft_clipped{0};
+          // decltype(alignmentScore) part_score = ez.mqe;//std::max(delCost, ez.mqe);
+          // int32_t num_soft_clipped{0};
           
-          if (allowSoftclip) {
-            auto max_score = std::max(ez.mqe, ez.mte);
-            // if we are allowing softclipping, then we consider the
-            // best score we could get as the maximum of
-            // 1. extending to the beginning of the query.
-            // 2. extending to the beginning of the reference.
-            // 3. 0 : i.e. performing no extension and starting the alignment at
-            // the first MEM.
-            if (max_score < 0) {
-              // if we are in case 3
-              part_score = 0;
-              // we soft clip the entire read part 
-              num_soft_clipped = readWindow.length();
-            } else if (ez.mqe >= ez.mte) {
-              // if we are in case 1
-              part_score = ez.mqe;
-              // we soft-clip nothing
-            } else {
-              // if we are in case 2
-              part_score = ez.mte;
-              // we soft clip the difference between the read part length 
-              // and the number of aligned bases in the read part
-              num_soft_clipped = readWindow.length() - ez.max_q - 1;
-            } 
-            arOut.softclip_start = static_cast<uint16_t>(num_soft_clipped);
-          } else if (allowOverhangSoftclip) {
-            if (ez.mte > ez.mqe) {
-              // we soft clip the difference between the read part length
-              // and the number of aligned bases in the read part
-              num_soft_clipped = readWindow.length() - ez.max_q - 1;
-              part_score = ez.mte;
-            } else {
-              part_score = ez.mqe;
-            }
-          }
-          alignmentScore += part_score;
-          if (approximateCIGAR and num_soft_clipped > 0) {
-            cigarGen.begin_softclip_len = num_soft_clipped;
-          }
+          // if (allowSoftclip) {
+          //   auto max_score = std::max(ez.mqe, ez.mte);
+          //   // if we are allowing softclipping, then we consider the
+          //   // best score we could get as the maximum of
+          //   // 1. extending to the beginning of the query.
+          //   // 2. extending to the beginning of the reference.
+          //   // 3. 0 : i.e. performing no extension and starting the alignment at
+          //   // the first MEM.
+          //   if (max_score < 0) {
+          //     // if we are in case 3
+          //     part_score = 0;
+          //     // we soft clip the entire read part 
+          //     num_soft_clipped = readWindow.length();
+          //   } else if (ez.mqe >= ez.mte) {
+          //     // if we are in case 1
+          //     part_score = ez.mqe;
+          //     // we soft-clip nothing
+          //   } else {
+          //     // if we are in case 2
+          //     part_score = ez.mte;
+          //     // we soft clip the difference between the read part length 
+          //     // and the number of aligned bases in the read part
+          //     num_soft_clipped = readWindow.length() - ez.max_q - 1;
+          //   } 
+          //   arOut.softclip_start = static_cast<uint16_t>(num_soft_clipped);
+          // } else if (allowOverhangSoftclip) {
+          //   if (ez.mte > ez.mqe) {
+          //     // we soft clip the difference between the read part length
+          //     // and the number of aligned bases in the read part
+          //     num_soft_clipped = readWindow.length() - ez.max_q - 1;
+          //     part_score = ez.mte;
+          //   } else {
+          //     part_score = ez.mqe;
+          //   }
+          // }
+          // alignmentScore += part_score;
+          // if (approximateCIGAR and num_soft_clipped > 0) {
+          //   cigarGen.begin_softclip_len = num_soft_clipped;
+          // }
 
           // NOTE: pre soft-clip code for adjusting the alignment score.
           // alignmentScore += allowOverhangSoftclip ? std::max(ez.mqe, ez.mte) : ez.mqe;
@@ -490,10 +566,26 @@ bool PuffAligner::alignRead(std::string& read, std::string& read_rc, const std::
           // score that we actually calculate.  However, if we are not writing
           // out the actual CIGAR string, this is the best we can do. (addresses
           // https://github.com/COMBINE-lab/salmon/issues/475).
-          openGapLen =
-              computeCIGAR ? addCigar(cigarGen, ez, true) : firstMemStart_read - num_soft_clipped;
-          SPDLOG_DEBUG(logger_, "score : {}", std::max(ez.mqe, ez.mte));
-        } else {
+          // openGapLen =
+          //     computeCIGAR ? addCigar(cigarGen, ez, true) : firstMemStart_read - num_soft_clipped;
+
+          decltype(alignmentScore) part_score = ez.max;
+          if(ez.mqe + aligner_config.end_bonus > ez.max)
+          {
+            part_score = ez.mqe;
+            openGapLen = readWindow.length();
+          }
+          else
+          {
+            part_score = ez.max;
+            openGapLen = ez.max_t + 1;
+            cigarGen.begin_softclip_len = readWindow.length() - (ez.max_q + 1);
+          }
+          alignmentScore += part_score;
+          addCigar(cigarGen, ez, true);
+          // logger_->debug("score : {}", std::max(ez.mqe, ez.mte));
+        } else { // EHSAN-TODO: check if this is necessary
+          logger_->debug("\t\t\tCASE 2: no reference bases left");
           // overhangingStart = true;
           // do any special soft clipping penalty here if we want
           alignmentScore +=
@@ -509,26 +601,38 @@ bool PuffAligner::alignRead(std::string& read, std::string& read_rc, const std::
             openGapLen = 0;
           }
         }
+        logger_->debug("\t\t\tscore_sofar: {}", alignmentScore);
+        logger_->debug("\t\t\tcigar_sofar: {}", cigarGen.get_cigar());
       }
 
       int32_t prevMemEnd_read = firstMemStart_read - 1; //isFw ? rpos : readLen - (rpos + memlen);
       int32_t prevMemEnd_ref = tpos - 1;
+      
       if (!alignable(prevMemEnd_read + 1, mopts.matchScore, alignmentScore)) {
         hctr.skippedAlignments_notAlignable += 1;
         ez.stopped = 1;
-        SPDLOG_DEBUG(logger_,"ez stopped");
+        logger_->debug("ez stopped");
       }
 
-      SPDLOG_DEBUG(logger_, "\t Aligning through MEM chain : ");
+      logger_->debug("\t\t### ADD MEM SCORE");
+      alignmentScore += mopts.matchScore * memlen;
+      cigarGen.add_item(memlen, 'M');
+      prevMemEnd_read = firstMemStart_read + memlen - 1;
+      prevMemEnd_ref = tpos + memlen - 1;
+
+      // logger_->debug("\t\t### Aligning through MEM chain: ");
       // for the second through the last mem
-      for(auto it = mems.begin(); it != mems.end() and !ez.stopped; ++it) {
+      for(auto it = mems.begin() + 1; it != mems.end() and !ez.stopped; ++it) {
+        logger_->debug("\t\t\tscore_sofar: {}", alignmentScore);
+        logger_->debug("\t\t\tcigar_sofar: {}", cigarGen.get_cigar());
+        logger_->debug("\t\t### FILL GAP");
         auto& mem = *it;
         rpos = mem.rpos;
         memlen = mem.extendedlen;
         tpos = mem.tpos;
+        logger_->debug("\t\t+++ NEXT MEM rpos: {}, tpos: {}, memLen: {}", (isFw ? rpos : readLen - (rpos + memlen)), tpos, memlen);
 
-        // first score the mem match
-        int32_t score = mopts.matchScore * memlen;
+        int32_t score = 0;
 
         int32_t currMemStart_ref = tpos;
         int32_t currMemStart_read = isFw ? rpos : readLen - (rpos + memlen);
@@ -536,36 +640,44 @@ bool PuffAligner::alignRead(std::string& read, std::string& read_rc, const std::
             currMemStart_ref - prevMemEnd_ref - 1; // both inclusive
         int32_t gapRead =
             currMemStart_read - prevMemEnd_read - 1; // both inclusive
+        
+        logger_->debug("\t\t\tgapRef: {}, gapRead: {}", gapRef, gapRead);
 
         if ((gapRef <= 0 or gapRead <= 0) and gapRef != gapRead) {
+          logger_->debug("\t\t\tCASE 1: overlapping MEMs");
           int32_t gapDiff = std::abs(gapRef - gapRead);
           score += (-1 * mopts.gapOpenPenalty +
                     -1 * mopts.gapExtendPenalty * gapDiff);
           // subtract off extra matches
           score += mopts.matchScore * std::min(gapRead, gapRef);
+          cigarGen.add_item(std::min(gapRead, gapRef), 'M');
+          if(gapRef > gapRead)
+          {
+            cigarGen.add_item(gapDiff, 'D');
+          }
+          else // gapRef < gapRead
+          {
+            cigarGen.add_item(gapDiff, 'I');
+          }
 
-          SPDLOG_DEBUG(logger_,
-                       "\t GAP NOT THE SAME:\n\t gapRef : {}, gapRead : {}",
-                       gapRef, gapRead);
-          SPDLOG_DEBUG(logger_, "\t totalScore (MEM + gapDiff) : {}", score);
+          logger_->debug("\t\t\t\tscore_adjustment: {}", score);
         } else if (gapRead > 0 and gapRef > 0) {
-          SPDLOG_DEBUG(logger_,
-                       "\t\t overlaps : \n\t\t gapRef : {}, gapRead : {}",
-                       gapRef, gapRead);
+          logger_->debug("\t\t\tCASE 2: gaps to align");
 
           auto readWindow = readView.substr(prevMemEnd_read + 1, gapRead);
           const char* refSeq1 = tseq.data() + (prevMemEnd_ref)-refStart + 1;
 
-          SPDLOG_DEBUG(logger_, "\t\t aligning\n\t\t [{}]\n\t\t\ [{}]",
-                       readWindow, nonstd::string_view(refSeq1, gapRef));
+          logger_->debug("\t\t\t\t[{}]\n\t\t\t\t[{}]", readWindow, nonstd::string_view(refSeq1, gapRef));
           if (prevMemEnd_ref - refStart + 1 + gapRef >= tseq.size()) {
-            SPDLOG_DEBUG(logger_,
-                         "\t\t tseq was not long enough; need to fetch more!");
+            logger_->debug("\t\t WARNING: tseq was not long enough; need to fetch more!");
           }
 
           if (readWindow.length() <= minLengthGapRequired and gapRead == gapRef) {
+            // EHSAN-TODO: add debug info here
+            logger_->debug("\t\t\t\taligning with align_ungapped (readWindow.length()={} < minLengthGapRequired={})", readWindow.length(), minLengthGapRequired);
             score += align_ungapped(readWindow.data(), refSeq1, gapRead);
           } else {
+            logger_->debug("\t\t\t\taligning with ksw2");
             ksw_reset_extz(&ez);
             bandwidth = maxAllowedGaps(prevMemEnd_read + 1, alignmentScore) + 1;
             score += aligner(
@@ -576,12 +688,14 @@ bool PuffAligner::alignRead(std::string& read, std::string& read_rc, const std::
               addCigar(cigarGen, ez, false);
             }
           }
+
+          logger_->debug("\t\t\t\tscore_adjustment: {}", score);
         } else if (it > mems.begin() and
                    ((currMemStart_read <= prevMemEnd_read) or
                     (currMemStart_ref <= prevMemEnd_ref))) {
-          SPDLOG_DEBUG(logger_, "]]\n");
-          std::cerr << "[ERROR in PuffAligner, between-MEM alignment] : "
-                       "Improperly compacted MEM chain.  Should not happen!\n";
+          logger_->debug("\t\t\tCASE 3: Improperly compacted MEM chain. Should not happen!");
+          std::cerr << "[ERROR in PuffAligner, between-MEM alignment]: "
+                    << "Improperly compacted MEM chain. Should not happen!\n";
           std::cerr << "gapRef : " << gapRef << ", gapRead : " << gapRead
                     << ", memlen : " << memlen << "\n";
           std::cerr << "prevMemEnd_read : " << prevMemEnd_read
@@ -591,43 +705,45 @@ bool PuffAligner::alignRead(std::string& read, std::string& read_rc, const std::
           std::exit(1);
         }
 
-        SPDLOG_DEBUG(logger_, "\t MEM (rpos : {}, memlen : {}, tpos : {})",
-                     rpos, memlen, tpos);
-        SPDLOG_DEBUG(logger_, "\t gapRef : {}, gapRead : {}", gapRef, gapRead);
-        auto printView = readView.substr(currMemStart_read, memlen);
-        auto refView =
-            nonstd::string_view(tseq.c_str() + tpos - refStart, memlen);
+        alignmentScore += score;
+        logger_->debug("\t\t\tscore_sofar: {}", alignmentScore);
+        logger_->debug("\t\t\tcigar_sofar: {}", cigarGen.get_cigar());
 
-        SPDLOG_DEBUG(logger_, "\t read [{}], pos : {}, len : {}, ori : {}",
-                     printView, currMemStart_read, memlen,
-                     (isFw ? "FW" : "RC"));
-        SPDLOG_DEBUG(logger_, "\t ref  [{}], pos : {}, len : {}", refView,
-                     currMemStart_ref, memlen);
-        if (printView.length() != refView.length()) {
-          SPDLOG_DEBUG(
-              logger_,
-              "\t readView length != refView length; should not happen!");
-          std::exit(1);
-        }
+        logger_->debug("\t\t### ADD MEM SCORE");
+        // EHSAN: do we really need this check? It has a tiny computational overhead!
+        // auto printView = readView.substr(currMemStart_read, memlen);
+        // auto refView = nonstd::string_view(tseq.c_str() + tpos - refStart, memlen);
+        // logger_->debug("\t\t\tread [{}], pos: {}, len: {}, ori: {}", printView, currMemStart_read, memlen, (isFw ? "FW" : "RC"));
+        // logger_->debug("\t\t\tref  [{}], pos: {}, len: {}", refView, currMemStart_ref, memlen);
+        // if (printView.length() != refView.length()) {
+        //   logger_->debug("\t\t\treadView length != refView length; should not happen!");
+        //   std::cerr << "[ERROR in PuffAligner, between-MEM alignment]: "
+        //             << "readView length != refView length; should not happen!" << "\t";
+        //   std::exit(1);
+        // }
+        // finally score the mem match
+        alignmentScore += mopts.matchScore * memlen;
+        cigarGen.add_item(memlen, 'M');
 
         prevMemEnd_read = currMemStart_read + memlen - 1;
         prevMemEnd_ref = tpos + memlen - 1;
-        alignmentScore += score;
 
         if (!alignable(prevMemEnd_read + 1, mopts.matchScore, alignmentScore)) {
           hctr.skippedAlignments_notAlignable += 1;
           ez.stopped = 1;
-          SPDLOG_DEBUG(logger_,"ez stopped");
+          logger_->debug("ez stopped");
         }
       }
+      
+      logger_->debug("\t\t\tscore_sofar: {}", alignmentScore);
+      logger_->debug("\t\t\tcigar_sofar: {}", cigarGen.get_cigar());
 
       // If we got to the end, and there is a read gap left, then align that as
       // well
-      SPDLOG_DEBUG(logger_, "prevMemEnd_read : {}, readLen : {}",
-                   prevMemEnd_read, readLen);
-      bool gapAtEnd =
-          (prevMemEnd_read + 1) <= (static_cast<int32_t>(readLen) - 1);
+      logger_->debug("\t\tprevMemEnd_read : {}, readLen : {}", prevMemEnd_read, readLen);
+      bool gapAtEnd = (prevMemEnd_read + 1) <= (static_cast<int32_t>(readLen) - 1);
       if (gapAtEnd and !ez.stopped) {
+        logger_->debug("\t\t### EXTEND RIGHT");
         int32_t gapRead = (readLen - 1) - (prevMemEnd_read + 1) + 1;
         int32_t refTailStart = prevMemEnd_ref + 1;
         bandwidth = maxAllowedGaps(prevMemEnd_read + 1, alignmentScore) + 1;
@@ -639,78 +755,99 @@ bool PuffAligner::alignRead(std::string& read, std::string& read_rc, const std::
         }
         int32_t refLen =
             (refTailEnd > refTailStart) ? refTailEnd - refTailStart + 1 : 0;
-        auto readWindow = readView.substr(prevMemEnd_read + 1);
-        fillRefSeqBuffer(allRefSeq, refAccPos, refTailStart, refLen,
-                         refSeqBuffer_);
+        auto readWindow = readView.substr(prevMemEnd_read + 1).to_string();
+        fillRefSeqBuffer(allRefSeq, refAccPos, refTailStart, refLen, refSeqBuffer_);
 
-        SPDLOG_DEBUG(logger_, "POST:");
-        SPDLOG_DEBUG(logger_, "read : [{}]", readWindow);
-        SPDLOG_DEBUG(logger_, "ref  : [{}]", refSeqBuffer_);
-        SPDLOG_DEBUG(logger_,
-                     "gapRead : {}, refLen : {}, refBuffer_.size() : {}, "
-                     "refTotalLength : {}",
-                     gapRead, refLen, refSeqBuffer_.size(), refTotalLength);
-
+        logger_->debug("\t\t\tgapRead : {}, refLen : {}, refBuffer_.size() : {}, refTotalLength : {}", gapRead, refLen, refSeqBuffer_.size(), refTotalLength);
         if (refLen > 0) {
+          logger_->debug("\t\t\tCASE 1: some reference bases left to align");
+          logger_->debug("\t\t\tread: [{}]", readWindow);
+          logger_->debug("\t\t\tref:  [{}]", refSeqBuffer_);
+
           ksw_reset_extz(&ez);
+          logger_->debug("\t\t\tksw2_parameters: bandwidth={}, end_bonus={}, zdrop={}", bandwidth, aligner_config.end_bonus, aligner_config.dropoff);
           auto cutoff = minAcceptedScore - alignmentScore - mopts.matchScore * readWindow.length();
           aligner(readWindow.data(), readWindow.length(), refSeqBuffer_.data(),
                   refLen, &ez, cutoff,
                   ksw2pp::EnumToType<ksw2pp::KSW2AlignmentType::EXTENSION>());
+          logger_->debug("\t\t\tksw2_results:");
+          logger_->debug("\t\t\t\tmax={}, max_q={}, max_t={}", ez.max, ez.max_q, ez.max_t);
+          logger_->debug("\t\t\t\tmqe_score={}, mqe_t={}", ez.mqe, ez.mqe_t);
+          logger_->debug("\t\t\t\tmte_score={}, mte_q={}", ez.mte, ez.mte_q);
+          logger_->debug("\t\t\t\tstopped={}, reach_end={}, zdropped={}, score={}", ez.stopped == 1, ez.reach_end == 1, ez.zdropped == 1, ez.score);
+          if(computeCIGAR) {
+            std::string tmp_cg_exp;
+            logger_->debug("\t\t\t\talnCigar: {}", ksw2_to_cigar(readWindow.c_str(), refSeqBuffer_.c_str(), &ez, tmp_cg_exp));
+            logger_->debug("\t\t\t\talnCigar: {}", collapse_cigar(tmp_cg_exp));
+          } 
           if (ez.stopped) hctr.skippedAlignments_notAlignable += 1;
           if (ez.mqe != KSW_NEG_INF) ez.stopped = 0;
-          // we start out with the score we obtain if we extend all the
-          // way to the end of the **query**.  This is the max score we can
-          // get by either
-          // simply deleting the rest of the read
-          int32_t delCost = (-1 * mopts.gapOpenPenalty +
-                             -1 * mopts.gapExtendPenalty * readWindow.length());
-          // or taking the ksw2 alignment score to the end fo the read
-          decltype(alignmentScore) part_score = std::max(ez.mqe, delCost);
 
-          int32_t num_soft_clipped{0};
-          if (allowSoftclip) {
-            // if we are allowing softclipping, then we consider the
-            // best score we could get as the maximum of
-            // 1. extending to the end of the query. (including deleting the
-            // rest of the query)
-            // 2. extending to the end of the reference.
-            // 3. 0 : i.e. performing no extension and end the alignment at the last MEM.
-            // NOTE: Since it won't affect the read position, we do not need to explicitly 
-            // compute the number of soft-clipped bases like we have above for the read part
-            // before the first MEM
-            // int32_t bases_clipped{0};
+          // // we start out with the score we obtain if we extend all the
+          // // way to the end of the **query**.  This is the max score we can
+          // // get by either
+          // // simply deleting the rest of the read
+          // int32_t delCost = (-1 * mopts.gapOpenPenalty +
+          //                    -1 * mopts.gapExtendPenalty * readWindow.length());
+          // // or taking the ksw2 alignment score to the end fo the read
+          // decltype(alignmentScore) part_score = std::max(ez.mqe, delCost);
 
-            // 1 is the default case here, and corresponds to clipping no bases
+          // int32_t num_soft_clipped{0};
+          // if (allowSoftclip) {
+          //   // if we are allowing softclipping, then we consider the
+          //   // best score we could get as the maximum of
+          //   // 1. extending to the end of the query. (including deleting the
+          //   // rest of the query)
+          //   // 2. extending to the end of the reference.
+          //   // 3. 0 : i.e. performing no extension and end the alignment at the last MEM.
+          //   // NOTE: Since it won't affect the read position, we do not need to explicitly 
+          //   // compute the number of soft-clipped bases like we have above for the read part
+          //   // before the first MEM
+          //   // int32_t bases_clipped{0};
 
-            if (ez.mte > 0 and ez.mte > part_score) {
-              // if we are in case 2
+          //   // 1 is the default case here, and corresponds to clipping no bases
 
-              // if extending to the end of the reference is better than the end
-              // of the query and if the score is greater than 0 (which we can
-              // always get when soft clipping) then take that
-              part_score = ez.mte;
-              num_soft_clipped = readWindow.length() - ez.max_q - 1;
-            } else if (part_score < 0) {
-              // if we are in case 3
-              part_score = 0;
-              num_soft_clipped = readWindow.length();
-            }
-          } else if (allowOverhangSoftclip) {
-            part_score = std::max(std::max(ez.mqe, ez.mte), part_score);
+          //   if (ez.mte > 0 and ez.mte > part_score) {
+          //     // if we are in case 2
+
+          //     // if extending to the end of the reference is better than the end
+          //     // of the query and if the score is greater than 0 (which we can
+          //     // always get when soft clipping) then take that
+          //     part_score = ez.mte;
+          //     num_soft_clipped = readWindow.length() - ez.max_q - 1;
+          //   } else if (part_score < 0) {
+          //     // if we are in case 3
+          //     part_score = 0;
+          //     num_soft_clipped = readWindow.length();
+          //   }
+          // } else if (allowOverhangSoftclip) {
+          //   part_score = std::max(std::max(ez.mqe, ez.mte), part_score);
+          // }
+          // alignmentScore += part_score;
+          // if (approximateCIGAR) {
+          //   cigarGen.end_softclip_len = num_soft_clipped;
+          // }
+
+          decltype(alignmentScore) part_score = ez.max;
+          if(ez.mqe + aligner_config.end_bonus > ez.max)
+          {
+            part_score = ez.mqe;
+          }
+          else
+          {
+            part_score = ez.max;
+            cigarGen.end_softclip_len = readWindow.length() - (ez.max_q + 1);
           }
           alignmentScore += part_score;
-          if (approximateCIGAR) {
-            cigarGen.end_softclip_len = num_soft_clipped;
-          }
+          addCigar(cigarGen, ez, false);
 
           // NOTE: pre soft-clip code for adjusting the alignment score.
           // int32_t alnCost = allowOverhangSoftclip ? std::max(ez.mqe, ez.mte)
           // : ez.mqe; int32_t delCost = (-1 * mopts.gapOpenPenalty + -1 *
           // mopts.gapExtendPenalty * readWindow.length()); alignmentScore +=
           // std::max(alnCost, delCost);
-          SPDLOG_DEBUG(logger_, "POST score : {}", part_score);
         } else {
+          logger_->debug("\t\t\tCASE 2: no reference bases left");
           //overhangingEnd = true;
           // do any special soft clipping penalty here if we want
           alignmentScore +=
@@ -723,15 +860,17 @@ bool PuffAligner::alignRead(std::string& read, std::string& read_rc, const std::
             cigarGen.endOverhang = true;
           }
         }
+        logger_->debug("\t\t\tscore_sofar: {}", alignmentScore);
+        logger_->debug("\t\t\tcigar_sofar: {}", cigarGen.get_cigar());
       }
-
-      SPDLOG_DEBUG(logger_, "score : {}\n]]\n", alignmentScore);
     }
-  } // not a perfect chain
+  // } // not a perfect chain
 
+  std::string cigar = "";
   bool cigar_fixed{false};
-  if (computeCIGAR) { cigar = cigarGen.get_cigar(readLen, cigar_fixed); }
-  if (approximateCIGAR) { cigarGen.get_approx_cigar(readLen, cigar); }
+  // if (computeCIGAR) { cigar = cigarGen.get_cigar(readLen, cigar_fixed); }
+  if (computeCIGAR) { cigar = cigarGen.get_cigar(); }
+  // if (approximateCIGAR) { cigarGen.get_approx_cigar(readLen, cigar); }
   if (cigar_fixed) { hctr.cigar_fixed_count++; }
   if (useAlnCache) { // don't bother to fill up a cache unless this is a multi-mapping read
     //mopts.useAlignmentCache and isMultimapping_ and !perfectChain and !overhangingEnd) { // don't bother to fill up a cache unless this is a multi-mapping read

--- a/src/Pufferfish.cpp
+++ b/src/Pufferfish.cpp
@@ -248,12 +248,11 @@ int main(int argc, char* argv[]) {
                       |
                       (required("-o", "--outdir") & value("output file", alignmentOpt.outname)) % "Output file where the alignment results will be stored"
                     ),
-                    // (option("--allowSoftclip").set(alignmentOpt.allowSoftclip, true) % "Allow soft-clipping at start and end of alignments"),
+                    (option("--allowSoftclip").set(alignmentOpt.allowSoftclip, true) % "Allow soft-clipping at start and end of alignments"),
+                    (option("--maxSoftclipFraction") & value("maxSoftclipFraction", alignmentOpt.maxSoftclipFraction)) % "Discard alignments with soft-clip > maxSoftclipFraction * read_length (default=0.2)",
                     // (option("--allowOverhangSoftclip").set(alignmentOpt.allowOverhangSoftclip, true) % "Allow soft-clipping part of a read that overhangs the reference (the regular --allowSoftclip flag overrides this one)"),
                     (option("--computeCIGAR").set(alignmentOpt.computeCIGAR, true) % "Compute CIGAR string during alignment validation"),
-                    (option("--debug").set(alignmentOpt.debug, true) % "Print debug information in standard error"),
-                    (option("--end2end").set(alignmentOpt.end2end, true) % "Perform end to end alignment with no soft-clipping"),
-                    (option("--maxSoftclipFraction") & value("maxSoftclipFraction", alignmentOpt.maxSoftclipFraction)) % "Discard alignments with soft-clip > maxSoftclipFraction * read_length (default=0.2)",
+                    // (option("--end2end").set(alignmentOpt.end2end, true) % "Perform end to end alignment with no soft-clipping"),
                     (option("--endBonus") & value("end bonus", alignmentOpt.endBonus)) % "Specify end bonus value when alignment reaches the end of query",
                     (option("--maxSpliceGap") & value("max splice gap", alignmentOpt.maxSpliceGap)) % "Specify maximum splice gap that two uni-MEMs should have",
                     (option("--maxFragmentLength") & value("max frag length", alignmentOpt.maxFragmentLength)) % 
@@ -272,6 +271,7 @@ int main(int argc, char* argv[]) {
                       (option("-p", "--pam").set(alignmentOpt.salmonOut, true)) % "Write output in the format required for salmon"
                     ),
 					(option("--verbose").set(alignmentOpt.verbose, true)) % "Print out auxilary information to trace program's flow",
+          (option("--debug").set(alignmentOpt.debug, true) % "Print debug information in standard error"),
                     (option("--fullAlignment").set(alignmentOpt.fullAlignment, true)) % "Perform full alignment instead of gapped alignment",
                     (option("--heuristicChaining").set(alignmentOpt.heuristicChaining, true)) % "Whether or not perform only 2 rounds of chaining",
                     (option("--bestStrata").set(alignmentOpt.bestStrata, true)) % "Keep only the alignments with the best score for each read",

--- a/src/Pufferfish.cpp
+++ b/src/Pufferfish.cpp
@@ -248,8 +248,10 @@ int main(int argc, char* argv[]) {
                       |
                       (required("-o", "--outdir") & value("output file", alignmentOpt.outname)) % "Output file where the alignment results will be stored"
                     ),
-                    (option("--allowSoftclip").set(alignmentOpt.allowSoftclip, true) % "Allow soft-clipping at start and end of alignments"),
-                    (option("--allowOverhangSoftclip").set(alignmentOpt.allowOverhangSoftclip, true) % "Allow soft-clipping part of a read that overhangs the reference (the regular --allowSoftclip flag overrides this one)"),
+                    // (option("--allowSoftclip").set(alignmentOpt.allowSoftclip, true) % "Allow soft-clipping at start and end of alignments"),
+                    // (option("--allowOverhangSoftclip").set(alignmentOpt.allowOverhangSoftclip, true) % "Allow soft-clipping part of a read that overhangs the reference (the regular --allowSoftclip flag overrides this one)"),
+                    (option("--computeCIGAR").set(alignmentOpt.computeCIGAR, true) % "Compute CIGAR string during alignment validation"),
+                    (option("--debug").set(alignmentOpt.debug, true) % "Print debug information in standard error"),
                     (option("--maxSpliceGap") & value("max splice gap", alignmentOpt.maxSpliceGap)) % "Specify maximum splice gap that two uni-MEMs should have",
                     (option("--maxFragmentLength") & value("max frag length", alignmentOpt.maxFragmentLength)) % 
                             "Specify the maximum distance between the last uni-MEM of the left and first uni-MEM of the right end of the read pairs (default:1000)",

--- a/src/Pufferfish.cpp
+++ b/src/Pufferfish.cpp
@@ -251,8 +251,8 @@ int main(int argc, char* argv[]) {
                     (option("--allowSoftclip").set(alignmentOpt.allowSoftclip, true) % "Allow soft-clipping at start and end of alignments"),
                     (option("--maxSoftclipFraction") & value("max softclip fraction general", alignmentOpt.maxSoftclipFractionGeneral)
                     & value("max softclip fraction overhang", alignmentOpt.maxSoftclipFractionOverhang)) % 
-                    "Discard alignments with soft-clip > maxSoftclipFraction * read_length." 
-                    "The general and overhang fractions should be specified differently."
+                    "Discard alignments with soft-clip > maxSoftclipFraction * read_length. " 
+                    "The general and overhang fractions should be specified differently. "
                     "This value must be in the range [0, 1] (default=0.2 0.2)",
                     (option("--computeCIGAR").set(alignmentOpt.computeCIGAR, true) % "Compute CIGAR string during alignment validation"),
                     (option("--endBonus") & value("end bonus", alignmentOpt.endBonus)) % "Specify end bonus value when alignment reaches the end of query",

--- a/src/Pufferfish.cpp
+++ b/src/Pufferfish.cpp
@@ -249,10 +249,11 @@ int main(int argc, char* argv[]) {
                       (required("-o", "--outdir") & value("output file", alignmentOpt.outname)) % "Output file where the alignment results will be stored"
                     ),
                     (option("--allowSoftclip").set(alignmentOpt.allowSoftclip, true) % "Allow soft-clipping at start and end of alignments"),
-                    (option("--maxSoftclipFraction") & value("maxSoftclipFractionGeneral", alignmentOpt.maxSoftclipFractionGeneral)
-                    & value("maxSoftclipFractionOverhang", alignmentOpt.maxSoftclipFractionOverhang)) % 
+                    (option("--maxSoftclipFraction") & value("max softclip fraction general", alignmentOpt.maxSoftclipFractionGeneral)
+                    & value("max softclip fraction overhang", alignmentOpt.maxSoftclipFractionOverhang)) % 
                     "Discard alignments with soft-clip > maxSoftclipFraction * read_length." 
-                    "The general and overhang fractions should be specified differently (default=0.2 0.2)",
+                    "The general and overhang fractions should be specified differently."
+                    "This value must be in the range [0, 1] (default=0.2 0.2)",
                     (option("--computeCIGAR").set(alignmentOpt.computeCIGAR, true) % "Compute CIGAR string during alignment validation"),
                     (option("--endBonus") & value("end bonus", alignmentOpt.endBonus)) % "Specify end bonus value when alignment reaches the end of query",
                     (option("--maxSpliceGap") & value("max splice gap", alignmentOpt.maxSpliceGap)) % "Specify maximum splice gap that two uni-MEMs should have",

--- a/src/Pufferfish.cpp
+++ b/src/Pufferfish.cpp
@@ -250,9 +250,7 @@ int main(int argc, char* argv[]) {
                     ),
                     (option("--allowSoftclip").set(alignmentOpt.allowSoftclip, true) % "Allow soft-clipping at start and end of alignments"),
                     (option("--maxSoftclipFraction") & value("maxSoftclipFraction", alignmentOpt.maxSoftclipFraction)) % "Discard alignments with soft-clip > maxSoftclipFraction * read_length (default=0.2)",
-                    // (option("--allowOverhangSoftclip").set(alignmentOpt.allowOverhangSoftclip, true) % "Allow soft-clipping part of a read that overhangs the reference (the regular --allowSoftclip flag overrides this one)"),
                     (option("--computeCIGAR").set(alignmentOpt.computeCIGAR, true) % "Compute CIGAR string during alignment validation"),
-                    // (option("--end2end").set(alignmentOpt.end2end, true) % "Perform end to end alignment with no soft-clipping"),
                     (option("--endBonus") & value("end bonus", alignmentOpt.endBonus)) % "Specify end bonus value when alignment reaches the end of query",
                     (option("--maxSpliceGap") & value("max splice gap", alignmentOpt.maxSpliceGap)) % "Specify maximum splice gap that two uni-MEMs should have",
                     (option("--maxFragmentLength") & value("max frag length", alignmentOpt.maxFragmentLength)) % 

--- a/src/Pufferfish.cpp
+++ b/src/Pufferfish.cpp
@@ -249,7 +249,10 @@ int main(int argc, char* argv[]) {
                       (required("-o", "--outdir") & value("output file", alignmentOpt.outname)) % "Output file where the alignment results will be stored"
                     ),
                     (option("--allowSoftclip").set(alignmentOpt.allowSoftclip, true) % "Allow soft-clipping at start and end of alignments"),
-                    (option("--maxSoftclipFraction") & value("maxSoftclipFraction", alignmentOpt.maxSoftclipFraction)) % "Discard alignments with soft-clip > maxSoftclipFraction * read_length (default=0.2)",
+                    (option("--maxSoftclipFraction") & value("maxSoftclipFractionGeneral", alignmentOpt.maxSoftclipFractionGeneral)
+                    & value("maxSoftclipFractionOverhang", alignmentOpt.maxSoftclipFractionOverhang)) % 
+                    "Discard alignments with soft-clip > maxSoftclipFraction * read_length." 
+                    "The general and overhang fractions should be specified differently (default=0.2 0.2)",
                     (option("--computeCIGAR").set(alignmentOpt.computeCIGAR, true) % "Compute CIGAR string during alignment validation"),
                     (option("--endBonus") & value("end bonus", alignmentOpt.endBonus)) % "Specify end bonus value when alignment reaches the end of query",
                     (option("--maxSpliceGap") & value("max splice gap", alignmentOpt.maxSpliceGap)) % "Specify maximum splice gap that two uni-MEMs should have",

--- a/src/Pufferfish.cpp
+++ b/src/Pufferfish.cpp
@@ -253,6 +253,7 @@ int main(int argc, char* argv[]) {
                     (option("--computeCIGAR").set(alignmentOpt.computeCIGAR, true) % "Compute CIGAR string during alignment validation"),
                     (option("--debug").set(alignmentOpt.debug, true) % "Print debug information in standard error"),
                     (option("--end2end").set(alignmentOpt.end2end, true) % "Perform end to end alignment with no soft-clipping"),
+                    (option("--maxSoftclipFraction") & value("maxSoftclipFraction", alignmentOpt.maxSoftclipFraction)) % "Discard alignments with soft-clip > maxSoftclipFraction * read_length (default=0.2)",
                     (option("--endBonus") & value("end bonus", alignmentOpt.endBonus)) % "Specify end bonus value when alignment reaches the end of query",
                     (option("--maxSpliceGap") & value("max splice gap", alignmentOpt.maxSpliceGap)) % "Specify maximum splice gap that two uni-MEMs should have",
                     (option("--maxFragmentLength") & value("max frag length", alignmentOpt.maxFragmentLength)) % 

--- a/src/Pufferfish.cpp
+++ b/src/Pufferfish.cpp
@@ -252,6 +252,8 @@ int main(int argc, char* argv[]) {
                     // (option("--allowOverhangSoftclip").set(alignmentOpt.allowOverhangSoftclip, true) % "Allow soft-clipping part of a read that overhangs the reference (the regular --allowSoftclip flag overrides this one)"),
                     (option("--computeCIGAR").set(alignmentOpt.computeCIGAR, true) % "Compute CIGAR string during alignment validation"),
                     (option("--debug").set(alignmentOpt.debug, true) % "Print debug information in standard error"),
+                    (option("--end2end").set(alignmentOpt.end2end, true) % "Perform end to end alignment with no soft-clipping"),
+                    (option("--endBonus") & value("end bonus", alignmentOpt.endBonus)) % "Specify end bonus value when alignment reaches the end of query",
                     (option("--maxSpliceGap") & value("max splice gap", alignmentOpt.maxSpliceGap)) % "Specify maximum splice gap that two uni-MEMs should have",
                     (option("--maxFragmentLength") & value("max frag length", alignmentOpt.maxFragmentLength)) % 
                             "Specify the maximum distance between the last uni-MEM of the left and first uni-MEM of the right end of the read pairs (default:1000)",

--- a/src/PufferfishAligner.cpp
+++ b/src/PufferfishAligner.cpp
@@ -311,7 +311,7 @@ void processReadsPair(paired_parser *parser,
                 for (auto &&jointHit : jointHits) {
                     const std::string& ref_name = pfi.refName(jointHit.tid);//txpNames[jointHit.tid];
                     logger_->debug("\n\tcalculate_alignments_PE ref_name: {} ref_ID: {}", ref_name, jointHit.tid);
-                    auto hitScore = puffaligner.calculateAlignments(rpair.first.seq, rpair.second.seq, jointHit, hctr, isMultimapping, verbose);
+                    auto hitScore = puffaligner.calculateAlignments(rpair.first.seq, rpair.second.seq, jointHit, hctr, isMultimapping, logger_, verbose);
                     if (mopts->bestStrata and hitScore != invalidScore)
                         puffaligner.getScoreStatus().updateBest(hitScore - mopts->matchScore * std::max(rpair.first.seq.length(), rpair.second.seq.length()));
                     if ( (mopts->filterGenomics or mopts->filterMicrobiom or mopts->filterMicrobiomBestScore) and hitScore != invalidScore)
@@ -727,7 +727,7 @@ void processReadsSingle(single_parser *parser,
                 for (auto &jointHit : jointHits) {
                     const std::string& ref_name = pfi.refName(jointHit.tid);//txpNames[jointHit.tid];
                     logger_->debug("\n\tcalculate_alignments_SE ref_name: {} ref_ID: {}", ref_name, jointHit.tid);
-                    int32_t hitScore = puffaligner.calculateAlignments(read.seq, jointHit, hctr, isMultimapping, verbose);
+                    int32_t hitScore = puffaligner.calculateAlignments(read.seq, jointHit, hctr, isMultimapping, logger_, verbose);
                     if (mopts->bestStrata) puffaligner.getScoreStatus().updateBest(hitScore);
                     if (mopts->filterGenomics or mopts->filterMicrobiom or mopts->filterMicrobiomBestScore) puffaligner.getScoreStatus().updateDecoy(hitScore);
                     scores[idx] = hitScore;

--- a/src/PufferfishAligner.cpp
+++ b/src/PufferfishAligner.cpp
@@ -122,14 +122,18 @@ void processReadsPair(paired_parser *parser,
     ksw2pp::KSW2Aligner aligner(mopts->matchScore, mopts->mismatchScore);
     ksw2pp::KSW2Config config;
 
-    config.dropoff = -1;
+    // config.dropoff = -1;
     config.gapo = mopts->gapOpenPenalty;
     config.gape = mopts->gapExtendPenalty;
     config.bandwidth = 15;
     config.flag = 0;
     config.flag |= KSW_EZ_RIGHT;
-    config.flag |= KSW_EZ_SCORE_ONLY;
+    if(mopts->allowSoftclip == false) {
+        config.flag |= KSW_EZ_SCORE_ONLY;
+    }
     aligner.config() = config;
+
+    auto logger_ = spdlog::get("console");
 
     constexpr const int32_t invalidScore = std::numeric_limits<int32_t>::min();
 
@@ -281,6 +285,8 @@ void processReadsPair(paired_parser *parser,
 #endif // ALLOW_VERBOSE
             }
             if (!mopts->justMap) {
+              logger_->debug("============================================================");
+              logger_->debug("process_PE read_name1: {}, read_name2: {}", rpair.first.name, rpair.second.name);
               puffaligner.clear();
               int32_t bestScore = invalidScore;
               std::vector<decltype(bestScore)> scores(jointHits.size(), bestScore);
@@ -298,6 +304,8 @@ void processReadsPair(paired_parser *parser,
 //                   ss << "\n\n found the read:\n" << rpair.first.name << " " << jointHits.size() <<"\n";
                 puffaligner.getScoreStatus().reset();
                 for (auto &&jointHit : jointHits) {
+                    const std::string& ref_name = pfi.refName(jointHit.tid);//txpNames[jointHit.tid];
+                    logger_->debug("\n\tcalculate_alignments_PE ref_name: {} ref_ID: {}", ref_name, jointHit.tid);
                     auto hitScore = puffaligner.calculateAlignments(rpair.first.seq, rpair.second.seq, jointHit, hctr, isMultimapping, verbose);
                     if (mopts->bestStrata and hitScore != invalidScore)
                         puffaligner.getScoreStatus().updateBest(hitScore - mopts->matchScore * std::max(rpair.first.seq.length(), rpair.second.seq.length()));
@@ -306,7 +314,6 @@ void processReadsPair(paired_parser *parser,
                     scores[idx] = hitScore;
 //                    if (verbose)
 //                        ss << txpNames[jointHit.tid] << " " << jointHit.alignmentScore << " " << scores[idx] << "\n";
-                    const std::string& ref_name = pfi.refName(jointHit.tid);//txpNames[jointHit.tid];
                     if (filterMicrobiom and hitScore != invalidScore
                     and hitRefType != BestHitReferenceType::FILTERED) {
                         bool inFilteredList = (rrna_names.find(ref_name) != rrna_names.end());
@@ -608,14 +615,18 @@ void processReadsSingle(single_parser *parser,
     ksw2pp::KSW2Aligner aligner(mopts->matchScore, mopts->mismatchScore);
     ksw2pp::KSW2Config config;
 
-    config.dropoff = -1;
+    // config.dropoff = -1;
     config.gapo = mopts->gapOpenPenalty;
     config.gape = mopts->gapExtendPenalty;
     config.bandwidth = 15;
     config.flag = 0;
     config.flag |= KSW_EZ_RIGHT;
-    config.flag |= KSW_EZ_SCORE_ONLY;
+    if(mopts->allowSoftclip == false) {
+        config.flag |= KSW_EZ_SCORE_ONLY;
+    }
     aligner.config() = config;
+
+    auto logger_ = spdlog::get("console");
 
     constexpr const int32_t invalidScore = std::numeric_limits<int32_t>::min();
 
@@ -688,6 +699,8 @@ void processReadsSingle(single_parser *parser,
             std::vector<std::pair<uint32_t, std::vector<pufferfish::util::MemCluster>::iterator>> validHits;
 
             if (!mopts->justMap) {
+                logger_->debug("============================================================");
+                logger_->debug("process_SE read_name: {}", read.name);
                 puffaligner.clear();
 
                 int32_t bestScore = invalidScore;
@@ -702,12 +715,13 @@ void processReadsSingle(single_parser *parser,
                 bool isMultimapping = (jointHits.size() > 1);
                 puffaligner.getScoreStatus().reset();
                 for (auto &jointHit : jointHits) {
+                    const std::string& ref_name = pfi.refName(jointHit.tid);//txpNames[jointHit.tid];
+                    logger_->debug("\n\tcalculate_alignments_SE ref_name: {} ref_ID: {}", ref_name, jointHit.tid);
                     int32_t hitScore = puffaligner.calculateAlignments(read.seq, jointHit, hctr, isMultimapping, verbose);
                     if (mopts->bestStrata) puffaligner.getScoreStatus().updateBest(hitScore);
                     if (mopts->filterGenomics or mopts->filterMicrobiom or mopts->filterMicrobiomBestScore) puffaligner.getScoreStatus().updateDecoy(hitScore);
                     scores[idx] = hitScore;
 
-                    const std::string& ref_name = pfi.refName(jointHit.tid);//txpNames[jointHit.tid];
                     if (filterGenomics or filterMicrobiom) {
                         bool inFilteredList = (gene_names.find(ref_name) != gene_names.end());
                         if (inFilteredList) {
@@ -1209,6 +1223,8 @@ bool alignReadsWrapper(
 int pufferfishAligner(pufferfish::AlignmentOpts &alnargs) {
 
     auto consoleLog = spdlog::stderr_color_mt("console");
+    consoleLog->set_pattern("%v");
+    spdlog::set_level(spdlog::level::debug);
     bool success{false};
     auto indexDir = alnargs.indexDir;
 

--- a/src/PufferfishAligner.cpp
+++ b/src/PufferfishAligner.cpp
@@ -157,7 +157,6 @@ void processReadsPair(paired_parser *parser,
     aconf.mimicBT2 = mopts->mimicBt2Default;
     aconf.allowSoftclip = mopts->allowSoftclip;
     aconf.computeCIGAR = (mopts->computeCIGAR and !mopts->noOutput);
-    aconf.endBonus = mopts->endBonus;
     aconf.end2end = !mopts->allowSoftclip;
     aconf.maxSoftclipFractionGeneral = mopts->maxSoftclipFractionGeneral;
     aconf.maxSoftclipFractionOverhang = mopts->maxSoftclipFractionOverhang;
@@ -645,7 +644,6 @@ void processReadsSingle(single_parser *parser,
     aconf.mimicBT2 = mopts->mimicBt2Default;
     aconf.allowSoftclip = mopts->allowSoftclip;
     aconf.computeCIGAR = (mopts->computeCIGAR and !mopts->noOutput);
-    aconf.endBonus = mopts->endBonus;
     aconf.end2end = !mopts->allowSoftclip;
     aconf.maxSoftclipFractionGeneral = mopts->maxSoftclipFractionGeneral;
     aconf.maxSoftclipFractionOverhang = mopts->maxSoftclipFractionOverhang;

--- a/src/PufferfishAligner.cpp
+++ b/src/PufferfishAligner.cpp
@@ -128,7 +128,7 @@ void processReadsPair(paired_parser *parser,
     config.bandwidth = 15;
     config.flag = 0;
     config.flag |= KSW_EZ_RIGHT;
-    if(mopts->allowSoftclip == false) {
+    if(mopts->computeCIGAR == false) {
         config.flag |= KSW_EZ_SCORE_ONLY;
     }
     aligner.config() = config;
@@ -155,9 +155,10 @@ void processReadsPair(paired_parser *parser,
     aconf.gapOpenPenalty = mopts->gapOpenPenalty;
     aconf.minScoreFraction = mopts->minScoreFraction;
     aconf.mimicBT2 = mopts->mimicBt2Default;
-    aconf.allowOverhangSoftclip = mopts->allowOverhangSoftclip;
-    aconf.allowSoftclip = mopts->allowSoftclip;
-    aconf.alignmentMode = mopts->noOutput or !mopts->allowSoftclip ? pufferfish::util::PuffAlignmentMode::SCORE_ONLY : pufferfish::util::PuffAlignmentMode::APPROXIMATE_CIGAR;
+    // aconf.allowOverhangSoftclip = mopts->allowOverhangSoftclip;
+    // aconf.allowSoftclip = mopts->allowSoftclip;
+    aconf.computeCIGAR = (mopts->computeCIGAR and !mopts->noOutput);
+    // aconf.alignmentMode = mopts->noOutput or !mopts->allowSoftclip ? pufferfish::util::PuffAlignmentMode::SCORE_ONLY : pufferfish::util::PuffAlignmentMode::APPROXIMATE_CIGAR;
     aconf.useAlignmentCache = mopts->useAlignmentCache;
     aconf.maxFragmentLength = mopts->maxFragmentLength;
     aconf.noDovetail = mopts->noDovetail;
@@ -621,7 +622,7 @@ void processReadsSingle(single_parser *parser,
     config.bandwidth = 15;
     config.flag = 0;
     config.flag |= KSW_EZ_RIGHT;
-    if(mopts->allowSoftclip == false) {
+    if(mopts->computeCIGAR == false) {
         config.flag |= KSW_EZ_SCORE_ONLY;
     }
     aligner.config() = config;
@@ -640,9 +641,10 @@ void processReadsSingle(single_parser *parser,
     aconf.gapOpenPenalty = mopts->gapOpenPenalty;
     aconf.minScoreFraction = mopts->minScoreFraction;
     aconf.mimicBT2 = mopts->mimicBt2Default;
-    aconf.allowOverhangSoftclip = mopts->allowOverhangSoftclip;
-    aconf.allowSoftclip = mopts->allowSoftclip;
-    aconf.alignmentMode = mopts->noOutput or !mopts->allowSoftclip ? pufferfish::util::PuffAlignmentMode::SCORE_ONLY : pufferfish::util::PuffAlignmentMode::APPROXIMATE_CIGAR;
+    // aconf.allowOverhangSoftclip = mopts->allowOverhangSoftclip;
+    // aconf.allowSoftclip = mopts->allowSoftclip;
+    aconf.computeCIGAR = (mopts->computeCIGAR and !mopts->noOutput);
+    // aconf.alignmentMode = mopts->noOutput or !mopts->allowSoftclip ? pufferfish::util::PuffAlignmentMode::SCORE_ONLY : pufferfish::util::PuffAlignmentMode::APPROXIMATE_CIGAR;
     aconf.useAlignmentCache = mopts->useAlignmentCache;
     aconf.mismatchPenalty = mopts->mismatchScore;
     aconf.bestStrata = mopts->bestStrata;
@@ -1224,7 +1226,7 @@ int pufferfishAligner(pufferfish::AlignmentOpts &alnargs) {
 
     auto consoleLog = spdlog::stderr_color_mt("console");
     consoleLog->set_pattern("%v");
-    spdlog::set_level(spdlog::level::debug);
+    if (alnargs.debug) spdlog::set_level(spdlog::level::debug);
     bool success{false};
     auto indexDir = alnargs.indexDir;
 

--- a/src/PufferfishAligner.cpp
+++ b/src/PufferfishAligner.cpp
@@ -160,7 +160,8 @@ void processReadsPair(paired_parser *parser,
     // aconf.allowSoftclip = mopts->allowSoftclip;
     aconf.computeCIGAR = (mopts->computeCIGAR and !mopts->noOutput);
     aconf.endBonus = mopts->endBonus;
-    aconf.endBonus = mopts->end2end;
+    aconf.end2end = mopts->end2end;
+    aconf.maxSoftclipFraction = mopts->maxSoftclipFraction;
     // aconf.alignmentMode = mopts->noOutput or !mopts->allowSoftclip ? pufferfish::util::PuffAlignmentMode::SCORE_ONLY : pufferfish::util::PuffAlignmentMode::APPROXIMATE_CIGAR;
     aconf.useAlignmentCache = mopts->useAlignmentCache;
     aconf.maxFragmentLength = mopts->maxFragmentLength;
@@ -650,6 +651,7 @@ void processReadsSingle(single_parser *parser,
     aconf.computeCIGAR = (mopts->computeCIGAR and !mopts->noOutput);
     aconf.endBonus = mopts->endBonus;
     aconf.end2end = mopts->end2end;
+    aconf.maxSoftclipFraction = mopts->maxSoftclipFraction;
     // aconf.alignmentMode = mopts->noOutput or !mopts->allowSoftclip ? pufferfish::util::PuffAlignmentMode::SCORE_ONLY : pufferfish::util::PuffAlignmentMode::APPROXIMATE_CIGAR;
     aconf.useAlignmentCache = mopts->useAlignmentCache;
     aconf.mismatchPenalty = mopts->mismatchScore;

--- a/src/PufferfishAligner.cpp
+++ b/src/PufferfishAligner.cpp
@@ -131,6 +131,7 @@ void processReadsPair(paired_parser *parser,
     if(mopts->computeCIGAR == false) {
         config.flag |= KSW_EZ_SCORE_ONLY;
     }
+    config.end_bonus = mopts->endBonus;
     aligner.config() = config;
 
     auto logger_ = spdlog::get("console");
@@ -158,6 +159,8 @@ void processReadsPair(paired_parser *parser,
     // aconf.allowOverhangSoftclip = mopts->allowOverhangSoftclip;
     // aconf.allowSoftclip = mopts->allowSoftclip;
     aconf.computeCIGAR = (mopts->computeCIGAR and !mopts->noOutput);
+    aconf.endBonus = mopts->endBonus;
+    aconf.endBonus = mopts->end2end;
     // aconf.alignmentMode = mopts->noOutput or !mopts->allowSoftclip ? pufferfish::util::PuffAlignmentMode::SCORE_ONLY : pufferfish::util::PuffAlignmentMode::APPROXIMATE_CIGAR;
     aconf.useAlignmentCache = mopts->useAlignmentCache;
     aconf.maxFragmentLength = mopts->maxFragmentLength;
@@ -625,6 +628,7 @@ void processReadsSingle(single_parser *parser,
     if(mopts->computeCIGAR == false) {
         config.flag |= KSW_EZ_SCORE_ONLY;
     }
+    config.end_bonus = mopts->endBonus;
     aligner.config() = config;
 
     auto logger_ = spdlog::get("console");
@@ -644,6 +648,8 @@ void processReadsSingle(single_parser *parser,
     // aconf.allowOverhangSoftclip = mopts->allowOverhangSoftclip;
     // aconf.allowSoftclip = mopts->allowSoftclip;
     aconf.computeCIGAR = (mopts->computeCIGAR and !mopts->noOutput);
+    aconf.endBonus = mopts->endBonus;
+    aconf.end2end = mopts->end2end;
     // aconf.alignmentMode = mopts->noOutput or !mopts->allowSoftclip ? pufferfish::util::PuffAlignmentMode::SCORE_ONLY : pufferfish::util::PuffAlignmentMode::APPROXIMATE_CIGAR;
     aconf.useAlignmentCache = mopts->useAlignmentCache;
     aconf.mismatchPenalty = mopts->mismatchScore;

--- a/src/PufferfishAligner.cpp
+++ b/src/PufferfishAligner.cpp
@@ -159,7 +159,8 @@ void processReadsPair(paired_parser *parser,
     aconf.computeCIGAR = (mopts->computeCIGAR and !mopts->noOutput);
     aconf.endBonus = mopts->endBonus;
     aconf.end2end = !mopts->allowSoftclip;
-    aconf.maxSoftclipFraction = mopts->maxSoftclipFraction;
+    aconf.maxSoftclipFractionGeneral = mopts->maxSoftclipFractionGeneral;
+    aconf.maxSoftclipFractionOverhang = mopts->maxSoftclipFractionOverhang;
     aconf.useAlignmentCache = mopts->useAlignmentCache;
     aconf.maxFragmentLength = mopts->maxFragmentLength;
     aconf.noDovetail = mopts->noDovetail;
@@ -646,7 +647,8 @@ void processReadsSingle(single_parser *parser,
     aconf.computeCIGAR = (mopts->computeCIGAR and !mopts->noOutput);
     aconf.endBonus = mopts->endBonus;
     aconf.end2end = !mopts->allowSoftclip;
-    aconf.maxSoftclipFraction = mopts->maxSoftclipFraction;
+    aconf.maxSoftclipFractionGeneral = mopts->maxSoftclipFractionGeneral;
+    aconf.maxSoftclipFractionOverhang = mopts->maxSoftclipFractionOverhang;
     aconf.useAlignmentCache = mopts->useAlignmentCache;
     aconf.mismatchPenalty = mopts->mismatchScore;
     aconf.bestStrata = mopts->bestStrata;

--- a/src/PufferfishAligner.cpp
+++ b/src/PufferfishAligner.cpp
@@ -95,7 +95,6 @@ void processReadsPair(paired_parser *parser,
     memCollector.setAltSkip(mopts->altSkip);
     memCollector.setChainSubOptThresh(mopts->preMergeChainSubThresh);
 
-    auto logger = spdlog::get("console");
     fmt::MemoryWriter sstream;
     BinWriter bstream;
 
@@ -122,7 +121,7 @@ void processReadsPair(paired_parser *parser,
     ksw2pp::KSW2Aligner aligner(mopts->matchScore, mopts->mismatchScore);
     ksw2pp::KSW2Config config;
 
-    // config.dropoff = -1;
+    config.dropoff = -1;
     config.gapo = mopts->gapOpenPenalty;
     config.gape = mopts->gapExtendPenalty;
     config.bandwidth = 15;
@@ -156,13 +155,11 @@ void processReadsPair(paired_parser *parser,
     aconf.gapOpenPenalty = mopts->gapOpenPenalty;
     aconf.minScoreFraction = mopts->minScoreFraction;
     aconf.mimicBT2 = mopts->mimicBt2Default;
-    // aconf.allowOverhangSoftclip = mopts->allowOverhangSoftclip;
     aconf.allowSoftclip = mopts->allowSoftclip;
     aconf.computeCIGAR = (mopts->computeCIGAR and !mopts->noOutput);
     aconf.endBonus = mopts->endBonus;
     aconf.end2end = !mopts->allowSoftclip;
     aconf.maxSoftclipFraction = mopts->maxSoftclipFraction;
-    // aconf.alignmentMode = mopts->noOutput or !mopts->allowSoftclip ? pufferfish::util::PuffAlignmentMode::SCORE_ONLY : pufferfish::util::PuffAlignmentMode::APPROXIMATE_CIGAR;
     aconf.useAlignmentCache = mopts->useAlignmentCache;
     aconf.maxFragmentLength = mopts->maxFragmentLength;
     aconf.noDovetail = mopts->noDovetail;
@@ -309,7 +306,7 @@ void processReadsPair(paired_parser *parser,
 //                   ss << "\n\n found the read:\n" << rpair.first.name << " " << jointHits.size() <<"\n";
                 puffaligner.getScoreStatus().reset();
                 for (auto &&jointHit : jointHits) {
-                    const std::string& ref_name = pfi.refName(jointHit.tid);//txpNames[jointHit.tid];
+                    const std::string& ref_name = pfi.refName(jointHit.tid);
                     logger_->debug("\n\tcalculate_alignments_PE ref_name: {} ref_ID: {}", ref_name, jointHit.tid);
                     auto hitScore = puffaligner.calculateAlignments(rpair.first.seq, rpair.second.seq, jointHit, hctr, isMultimapping, logger_, verbose);
                     if (mopts->bestStrata and hitScore != invalidScore)
@@ -597,7 +594,6 @@ void processReadsSingle(single_parser *parser,
     BestHitReferenceType bestHitRefType{BestHitReferenceType::UNKNOWN};
     phmap::flat_hash_map<uint32_t, std::pair<int32_t, int32_t>> bestScorePerTranscript;
 
-    auto logger = spdlog::get("console");
     fmt::MemoryWriter sstream;
     BinWriter bstream;
     //size_t batchSize{2500} ;
@@ -620,7 +616,7 @@ void processReadsSingle(single_parser *parser,
     ksw2pp::KSW2Aligner aligner(mopts->matchScore, mopts->mismatchScore);
     ksw2pp::KSW2Config config;
 
-    // config.dropoff = -1;
+    config.dropoff = -1;
     config.gapo = mopts->gapOpenPenalty;
     config.gape = mopts->gapExtendPenalty;
     config.bandwidth = 15;
@@ -646,13 +642,11 @@ void processReadsSingle(single_parser *parser,
     aconf.gapOpenPenalty = mopts->gapOpenPenalty;
     aconf.minScoreFraction = mopts->minScoreFraction;
     aconf.mimicBT2 = mopts->mimicBt2Default;
-    // aconf.allowOverhangSoftclip = mopts->allowOverhangSoftclip;
     aconf.allowSoftclip = mopts->allowSoftclip;
     aconf.computeCIGAR = (mopts->computeCIGAR and !mopts->noOutput);
     aconf.endBonus = mopts->endBonus;
     aconf.end2end = !mopts->allowSoftclip;
     aconf.maxSoftclipFraction = mopts->maxSoftclipFraction;
-    // aconf.alignmentMode = mopts->noOutput or !mopts->allowSoftclip ? pufferfish::util::PuffAlignmentMode::SCORE_ONLY : pufferfish::util::PuffAlignmentMode::APPROXIMATE_CIGAR;
     aconf.useAlignmentCache = mopts->useAlignmentCache;
     aconf.mismatchPenalty = mopts->mismatchScore;
     aconf.bestStrata = mopts->bestStrata;
@@ -725,7 +719,7 @@ void processReadsSingle(single_parser *parser,
                 bool isMultimapping = (jointHits.size() > 1);
                 puffaligner.getScoreStatus().reset();
                 for (auto &jointHit : jointHits) {
-                    const std::string& ref_name = pfi.refName(jointHit.tid);//txpNames[jointHit.tid];
+                    const std::string& ref_name = pfi.refName(jointHit.tid);
                     logger_->debug("\n\tcalculate_alignments_SE ref_name: {} ref_ID: {}", ref_name, jointHit.tid);
                     int32_t hitScore = puffaligner.calculateAlignments(read.seq, jointHit, hctr, isMultimapping, logger_, verbose);
                     if (mopts->bestStrata) puffaligner.getScoreStatus().updateBest(hitScore);

--- a/src/PufferfishAligner.cpp
+++ b/src/PufferfishAligner.cpp
@@ -157,10 +157,10 @@ void processReadsPair(paired_parser *parser,
     aconf.minScoreFraction = mopts->minScoreFraction;
     aconf.mimicBT2 = mopts->mimicBt2Default;
     // aconf.allowOverhangSoftclip = mopts->allowOverhangSoftclip;
-    // aconf.allowSoftclip = mopts->allowSoftclip;
+    aconf.allowSoftclip = mopts->allowSoftclip;
     aconf.computeCIGAR = (mopts->computeCIGAR and !mopts->noOutput);
     aconf.endBonus = mopts->endBonus;
-    aconf.end2end = mopts->end2end;
+    aconf.end2end = !mopts->allowSoftclip;
     aconf.maxSoftclipFraction = mopts->maxSoftclipFraction;
     // aconf.alignmentMode = mopts->noOutput or !mopts->allowSoftclip ? pufferfish::util::PuffAlignmentMode::SCORE_ONLY : pufferfish::util::PuffAlignmentMode::APPROXIMATE_CIGAR;
     aconf.useAlignmentCache = mopts->useAlignmentCache;
@@ -647,10 +647,10 @@ void processReadsSingle(single_parser *parser,
     aconf.minScoreFraction = mopts->minScoreFraction;
     aconf.mimicBT2 = mopts->mimicBt2Default;
     // aconf.allowOverhangSoftclip = mopts->allowOverhangSoftclip;
-    // aconf.allowSoftclip = mopts->allowSoftclip;
+    aconf.allowSoftclip = mopts->allowSoftclip;
     aconf.computeCIGAR = (mopts->computeCIGAR and !mopts->noOutput);
     aconf.endBonus = mopts->endBonus;
-    aconf.end2end = mopts->end2end;
+    aconf.end2end = !mopts->allowSoftclip;
     aconf.maxSoftclipFraction = mopts->maxSoftclipFraction;
     // aconf.alignmentMode = mopts->noOutput or !mopts->allowSoftclip ? pufferfish::util::PuffAlignmentMode::SCORE_ONLY : pufferfish::util::PuffAlignmentMode::APPROXIMATE_CIGAR;
     aconf.useAlignmentCache = mopts->useAlignmentCache;

--- a/src/ksw2pp/KSW2Aligner.cpp
+++ b/src/ksw2pp/KSW2Aligner.cpp
@@ -239,6 +239,10 @@ int KSW2Aligner::operator()(const char* const queryOriginal,
   int max_qt_len = (queryLength > targetLength) ? queryLength : targetLength;
   int w = (config_.bandwidth > max_qt_len) ? max_qt_len : config_.bandwidth;
   int z = config_.dropoff;
+  config_.flag |= KSW_EZ_EXTZ_ONLY;
+  std::cout<< "gapo:" << int(config_.gapo) << " gape:" << int(config_.gape) << std::endl;
+  for(uint32_t ii = 0; ii < mat_.size(); ii++) std::cout<< "\tmat[" << ii << "]: " << int(mat_[ii]) << std::endl;
+  std::cout<< "end_bonus:" << config_.end_bonus << " flag:" << config_.flag << " zdrop:" << config_.dropoff << std::endl;
   if (haveSSE41) {
     ksw_extz2_sse41(kalloc_allocator_.get(), qlen, query_.data(), tlen,
                 target_.data(), config_.alphabetSize, mat_.data(), q, e, w, z,

--- a/src/ksw2pp/KSW2Aligner.cpp
+++ b/src/ksw2pp/KSW2Aligner.cpp
@@ -240,9 +240,6 @@ int KSW2Aligner::operator()(const char* const queryOriginal,
   int w = (config_.bandwidth > max_qt_len) ? max_qt_len : config_.bandwidth;
   int z = config_.dropoff;
   config_.flag |= KSW_EZ_EXTZ_ONLY;
-  std::cout<< "gapo:" << int(config_.gapo) << " gape:" << int(config_.gape) << std::endl;
-  for(uint32_t ii = 0; ii < mat_.size(); ii++) std::cout<< "\tmat[" << ii << "]: " << int(mat_[ii]) << std::endl;
-  std::cout<< "end_bonus:" << config_.end_bonus << " flag:" << config_.flag << " zdrop:" << config_.dropoff << std::endl;
   if (haveSSE41) {
     ksw_extz2_sse41(kalloc_allocator_.get(), qlen, query_.data(), tlen,
                 target_.data(), config_.alphabetSize, mat_.data(), q, e, w, z,

--- a/src/ksw2pp/KSW2Aligner.cpp
+++ b/src/ksw2pp/KSW2Aligner.cpp
@@ -223,7 +223,7 @@ int KSW2Aligner::operator()(const char* const queryOriginal,
                             const int queryLength,
                             const char* const targetOriginal,
                             const int targetLength, ksw_extz_t* ez,
-                            int cutoff,
+                            int cutoff, int maxSoftclip,
                             EnumToType<KSW2AlignmentType::EXTENSION>) {
   // NOTE: all ksw extension aligner calls clear out ez 
   // *internally*.  This is why we do not need to (and do not)
@@ -243,11 +243,11 @@ int KSW2Aligner::operator()(const char* const queryOriginal,
   if (haveSSE41) {
     ksw_extz2_sse41(kalloc_allocator_.get(), qlen, query_.data(), tlen,
                 target_.data(), config_.alphabetSize, mat_.data(), q, e, w, z,
-                config_.end_bonus, config_.flag, ez, cutoff);
+                config_.end_bonus, config_.flag, ez, cutoff, maxSoftclip);
   } else if (haveSSE2) {
     ksw_extz2_sse2(kalloc_allocator_.get(), qlen, query_.data(), tlen,
                   target_.data(), config_.alphabetSize, mat_.data(), q, e, w, z,
-                  config_.end_bonus, config_.flag, ez, cutoff);
+                  config_.end_bonus, config_.flag, ez, cutoff, maxSoftclip);
   } else {
     std::abort();
   }
@@ -261,6 +261,7 @@ int KSW2Aligner::operator()(const char* const queryOriginal,
                             EnumToType<KSW2AlignmentType::EXTENSION>) {
   return this->operator()(queryOriginal, queryLength, targetOriginal,
                           targetLength, &result_, std::numeric_limits<int>::min(),
+                          std::numeric_limits<int>::max(),
                           EnumToType<KSW2AlignmentType::EXTENSION>());
 }
 
@@ -273,6 +274,7 @@ int KSW2Aligner::operator()(const char* const queryOriginal,
   case KSW2AlignmentType::EXTENSION:
     ret = this->operator()(queryOriginal, queryLength, targetOriginal,
                            targetLength, &result_, std::numeric_limits<int>::min(),
+                           std::numeric_limits<int>::max(),
                            EnumToType<KSW2AlignmentType::EXTENSION>());
     break;
   case KSW2AlignmentType::GLOBAL:
@@ -360,6 +362,7 @@ int KSW2Aligner::operator()(const uint8_t* const query_, const int queryLength,
   switch (config_.atype) {
   case KSW2AlignmentType::EXTENSION:
     ret = this->operator()(query_, queryLength, target_, targetLength, &result_, std::numeric_limits<int>::min(),
+                           std::numeric_limits<int>::max(),  
                            EnumToType<KSW2AlignmentType::EXTENSION>());
     break;
   case KSW2AlignmentType::GLOBAL:
@@ -372,7 +375,7 @@ int KSW2Aligner::operator()(const uint8_t* const query_, const int queryLength,
 
 int KSW2Aligner::operator()(const uint8_t* const query_, const int queryLength,
                             const uint8_t* const target_,
-                            const int targetLength, ksw_extz_t* ez, int cutoff,
+                            const int targetLength, ksw_extz_t* ez, int cutoff, int maxSoftclip,
                             EnumToType<KSW2AlignmentType::EXTENSION>) {
   // NOTE: all ksw extension aligner calls clear out ez 
   // *internally*.  This is why we do not need to (and do not)
@@ -388,11 +391,11 @@ int KSW2Aligner::operator()(const uint8_t* const query_, const int queryLength,
   if (haveSSE41) {
     ksw_extz2_sse41(kalloc_allocator_.get(), qlen, query_, tlen, target_,
                 config_.alphabetSize, mat_.data(), q, e, w, z, config_.end_bonus, config_.flag,
-                ez, cutoff);
+                ez, cutoff, maxSoftclip);
   } else if (haveSSE2) {
     ksw_extz2_sse2(kalloc_allocator_.get(), qlen, query_, tlen, target_,
                   config_.alphabetSize, mat_.data(), q, e, w, z, config_.end_bonus, config_.flag,
-                  ez, cutoff);
+                  ez, cutoff, maxSoftclip);
   } else {
     std::abort();
   }
@@ -404,6 +407,7 @@ int KSW2Aligner::operator()(const uint8_t* const query_, const int queryLength,
                             const int targetLength,
                             EnumToType<KSW2AlignmentType::EXTENSION>) {
   return this->operator()(query_, queryLength, target_, targetLength, &result_, std::numeric_limits<int>::min(),
+                          std::numeric_limits<int>::max(),
                           EnumToType<KSW2AlignmentType::EXTENSION>());
 }
 

--- a/src/ksw2pp/ksw2_extz2_sse.c
+++ b/src/ksw2pp/ksw2_extz2_sse.c
@@ -315,7 +315,7 @@ void ksw_extz2_sse(void *km, int qlen, const uint8_t *query, int tlen, const uin
 		int rev_cigar = !!(flag & KSW_EZ_REV_CIGAR);
 		if (!ez->zdropped && !(flag&KSW_EZ_EXTZ_ONLY)) {
 			ksw_backtrack(km, 1, rev_cigar, 0, (uint8_t*)p, off, off_end, n_col_*16, tlen-1, qlen-1, &ez->m_cigar, &ez->n_cigar, &ez->cigar);
-		} else if (!ez->zdropped && (flag&KSW_EZ_EXTZ_ONLY) && (ez->mqe + end_bonus > (int)ez->max || (qlen - (ez->max_q + 1) > max_sc_len))) {
+		} else if (!ez->zdropped && (flag&KSW_EZ_EXTZ_ONLY) && ((ez->mqe + end_bonus > (int)ez->max) || (qlen - (ez->max_q + 1) > max_sc_len))) {
 			ez->reach_end = 1;
 			ksw_backtrack(km, 1, rev_cigar, 0, (uint8_t*)p, off, off_end, n_col_*16, ez->mqe_t, qlen-1, &ez->m_cigar, &ez->n_cigar, &ez->cigar);
 		} else if (ez->max_t >= 0 && ez->max_q >= 0) {

--- a/src/ksw2pp/ksw2_extz2_sse.c
+++ b/src/ksw2pp/ksw2_extz2_sse.c
@@ -17,12 +17,12 @@
 
 #ifdef KSW_CPU_DISPATCH
 #ifdef __SSE4_1__
-void ksw_extz2_sse41(void *km, int qlen, const uint8_t *query, int tlen, const uint8_t *target, int8_t m, const int8_t *mat, int8_t q, int8_t e, int w, int zdrop, int end_bonus, int flag, ksw_extz_t *ez, int cutoff)
+void ksw_extz2_sse41(void *km, int qlen, const uint8_t *query, int tlen, const uint8_t *target, int8_t m, const int8_t *mat, int8_t q, int8_t e, int w, int zdrop, int end_bonus, int flag, ksw_extz_t *ez, int cutoff, int max_sc_len)
 #else
-void ksw_extz2_sse2(void *km, int qlen, const uint8_t *query, int tlen, const uint8_t *target, int8_t m, const int8_t *mat, int8_t q, int8_t e, int w, int zdrop, int end_bonus, int flag, ksw_extz_t *ez, int cutoff)
+void ksw_extz2_sse2(void *km, int qlen, const uint8_t *query, int tlen, const uint8_t *target, int8_t m, const int8_t *mat, int8_t q, int8_t e, int w, int zdrop, int end_bonus, int flag, ksw_extz_t *ez, int cutoff, int max_sc_len)
 #endif
 #else
-void ksw_extz2_sse(void *km, int qlen, const uint8_t *query, int tlen, const uint8_t *target, int8_t m, const int8_t *mat, int8_t q, int8_t e, int w, int zdrop, int end_bonus, int flag, ksw_extz_t *ez, int cutoff)
+void ksw_extz2_sse(void *km, int qlen, const uint8_t *query, int tlen, const uint8_t *target, int8_t m, const int8_t *mat, int8_t q, int8_t e, int w, int zdrop, int end_bonus, int flag, ksw_extz_t *ez, int cutoff, int max_sc_len)
 #endif // ~KSW_CPU_DISPATCH
 {
 #define __dp_code_block1 \
@@ -315,7 +315,7 @@ void ksw_extz2_sse(void *km, int qlen, const uint8_t *query, int tlen, const uin
 		int rev_cigar = !!(flag & KSW_EZ_REV_CIGAR);
 		if (!ez->zdropped && !(flag&KSW_EZ_EXTZ_ONLY)) {
 			ksw_backtrack(km, 1, rev_cigar, 0, (uint8_t*)p, off, off_end, n_col_*16, tlen-1, qlen-1, &ez->m_cigar, &ez->n_cigar, &ez->cigar);
-		} else if (!ez->zdropped && (flag&KSW_EZ_EXTZ_ONLY) && ez->mqe + end_bonus > (int)ez->max) {
+		} else if (!ez->zdropped && (flag&KSW_EZ_EXTZ_ONLY) && (ez->mqe + end_bonus > (int)ez->max || (qlen - (ez->max_q + 1) > max_sc_len))) {
 			ez->reach_end = 1;
 			ksw_backtrack(km, 1, rev_cigar, 0, (uint8_t*)p, off, off_end, n_col_*16, ez->mqe_t, qlen-1, &ez->m_cigar, &ez->n_cigar, &ez->cigar);
 		} else if (ez->max_t >= 0 && ez->max_q >= 0) {


### PR DESCRIPTION
Here is a short summary of the changes:
- [x] Enabling soft-clipping
  * Proper use of KSW2 alignment results: Track the best scoring prefix alignment (during KSW2 extension) in addition to full alignment of query or target
  * Reducing `end_bonus` value from 10 to 5
  * Setting the alignment start coordinate accordingly
- [x] Computing CIGAR strings:
  * Setting `KSW_EZ_EXTZ_ONLY` flag for KSW2 extension alignments (otherwise it always backtrack from the end of both sequences)
  * Modifying `CIGARGenerator`'s variable type to enable computation of CIGAR for cases with overlapping MEMs (`uint32_t` to `int32_t`)
  * Updating get_cigar function and removing unnecessary codes
- [x] Logging more organized debug information for alignment validation
- [x] Improving the command-line interface
  * replacing `--allowSoftclip` and `--allowOverhangSoftclip` with `--computeCIGAR`
  * adding a `--debug`; if not used, no debug information will be printed

With these changes I compared the output of PuffAligner with Minimap2 **for single-end reads**. This comparison showed that generally, the alignment is computed correctly in most of the cases. 

**The next essential step:** In some cases the alignment is wrong. The reason is that the extension is stopped (ez->stopped==1) and therefore, the score for reaching the end of query is not calculated properly. As a result, it might be the case that score for reaching end of query is **incorrectly** higher than the maximum scoring prefix alignment. Here is an example:
```
pufferfish alignment
TCAAAAACATGATTACAGGGACATCTCAGGCTGACTGTGCTGTCCTGATTGTTGCTGCTGGTGTTGGTGAATTTGAAGCTGGTATCTCCAAGAATGGGCN
||||||||||||||||||||||||||||||||||||x|||||||||||||||||||||||||||||||||||||||||x|x|x|||x|||x||||||||x
TCAAAAACATGATTACAGGGACATCTCAGGCTGACTCTGCTGTCCTGATTGTTGCTGCTGGTGTTGGTGAATTTGAAGGTAGCATCCCCAGGAATGGGCA

minimap alignment
TCAAAAACATGATTACAGGGACATCTCAGGCTGACTGTGCTGTCCTGATTGTTGCTGCTGGTGTTGGTGAATTTGAAG----------------------
||||||||||||||||||||||||||||||||||||x|||||||||||||||||||||||||||||||||||||||||
TCAAAAACATGATTACAGGGACATCTCAGGCTGACTCTGCTGTCCTGATTGTTGCTGCTGGTGTTGGTGAATTTGAAGGTAGCATCCCCAGGAATGGGCA
```
It seems that extension stopping was not written with soft-clipping and computation of CIGAR strings in mind, so this requires a fix.
I will check if the original KSW2 extension fixes this issue and if it does, we can discuss about whether it's worth to have the stopping feature or not.

So next items:
- [x] Checking if using original KSW2 extension fixes edge case wrong alignments
- [x] Testing and verifying alignment coordinate, soft-clipping and CIGAR string for overhanging reads
- [x] Testing for PE datasets
- [x] Adding an option for passing `end_bonus` value
- [x] Code cleaning (currently there is a lot of commented code in this branch)
