### PR TITLE
Including missing cstdint in Taxa.h, constructLineage.cpp

### DIFF
--- a/include/cedar/Taxa.h
+++ b/include/cedar/Taxa.h
@@ -4,6 +4,7 @@
 #include <string>
 #include <vector>
 #include <set> // std::set
+#include <cstdint>
 #include "iostream"
 
 #define NO_PARENT -1

--- a/src/constructLineage.cpp
+++ b/src/constructLineage.cpp
@@ -6,6 +6,7 @@
 #include <vector>
 #include <queue>
 #include <sstream>
+#include <cstdint>
 
 constexpr uint64_t noRank = 1;
 


### PR DESCRIPTION
I needed to add these includes for the `develop` branch to compile for me.